### PR TITLE
mpi diffusion timestep 2d

### DIFF
--- a/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_2d/__init__.py
+++ b/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_2d/__init__.py
@@ -1,1 +1,4 @@
 from .diffusion_flux_mpi_2d import gen_diffusion_flux_pyst_mpi_kernel_2d
+from .diffusion_timestep_mpi_2d import (
+    gen_diffusion_timestep_euler_forward_pyst_mpi_kernel_2d,
+)

--- a/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_2d/diffusion_flux_mpi_2d.py
+++ b/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_2d/diffusion_flux_mpi_2d.py
@@ -13,9 +13,12 @@ def gen_diffusion_flux_pyst_mpi_kernel_2d(
     # boundary crunching
     diffusion_flux_pyst_kernel = gen_diffusion_flux_pyst_kernel_2d(real_t=real_t)
     kernel_support = 1
+    # define this here so that ghost size and kernel support is checked during
+    # generation phase itself
+    gen_diffusion_flux_pyst_mpi_kernel_2d.kernel_support = kernel_support
     check_valid_ghost_size_and_kernel_support(
         ghost_size=ghost_exchange_communicator.ghost_size,
-        kernel_support=kernel_support,
+        kernel_support=gen_diffusion_flux_pyst_mpi_kernel_2d.kernel_support,
     )
 
     def diffusion_flux_pyst_mpi_kernel_2d(
@@ -24,7 +27,9 @@ def gen_diffusion_flux_pyst_mpi_kernel_2d(
         prefactor,
     ):
         # define kernel support for kernel
-        diffusion_flux_pyst_mpi_kernel_2d.kernel_support = kernel_support
+        diffusion_flux_pyst_mpi_kernel_2d.kernel_support = (
+            gen_diffusion_flux_pyst_mpi_kernel_2d.kernel_support
+        )
         # define variable for use later
         ghost_size = ghost_exchange_communicator.ghost_size
         # begin ghost comm.

--- a/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_2d/diffusion_timestep_mpi_2d.py
+++ b/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_2d/diffusion_timestep_mpi_2d.py
@@ -26,8 +26,8 @@ def gen_diffusion_timestep_euler_forward_pyst_mpi_kernel_2d(
     # Since the generated function has not been called yet, we cannot access the
     # kernel support variable. However, because of the way we implemented the
     # generator function, we can retrieve it from the generator function.
-    # define this here so that ghost size and kernel support is checked during
-    # generation phase itself
+    # Define the variables below so that we check ghost size and kernel support
+    # during generation phase itself
     kernel_support = gen_diffusion_flux_pyst_mpi_kernel_2d.kernel_support
     gen_diffusion_timestep_euler_forward_pyst_mpi_kernel_2d.kernel_support = (
         kernel_support

--- a/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_2d/diffusion_timestep_mpi_2d.py
+++ b/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_2d/diffusion_timestep_mpi_2d.py
@@ -1,0 +1,62 @@
+"""MPI-supported kernels for performing diffusion timestep in 2D."""
+from tabnanny import check
+from sopht_mpi.numeric.eulerian_grid_ops.stencil_ops_2d.diffusion_flux_mpi_2d import (
+    gen_diffusion_flux_pyst_mpi_kernel_2d,
+)
+from sopht.numeric.eulerian_grid_ops.stencil_ops_2d.elementwise_ops_2d import (
+    gen_elementwise_sum_pyst_kernel_2d,
+    gen_set_fixed_val_pyst_kernel_2d,
+)
+from sopht_mpi.utils.mpi_utils import check_valid_ghost_size_and_kernel_support
+
+
+def gen_diffusion_timestep_euler_forward_pyst_mpi_kernel_2d(
+    real_t,
+    mpi_construct,
+    ghost_exchange_communicator,
+):
+    """MPI-supported 2D diffusion euler forward timestep generator"""
+    elementwise_sum_pyst_kernel_2d = gen_elementwise_sum_pyst_kernel_2d(real_t=real_t)
+    set_fixed_val_pyst_kernel_2d = gen_set_fixed_val_pyst_kernel_2d(real_t=real_t)
+    diffusion_flux_mpi_kernel_2d = gen_diffusion_flux_pyst_mpi_kernel_2d(
+        real_t=real_t,
+        mpi_construct=mpi_construct,
+        ghost_exchange_communicator=ghost_exchange_communicator,
+    )
+    # Since the generated function has not been called yet, we cannot access the
+    # kernel support variable. However, because of the way we implemented the
+    # generator function, we can retrieve it from the generator function.
+    # define this here so that ghost size and kernel support is checked during
+    # generation phase itself
+    kernel_support = gen_diffusion_flux_pyst_mpi_kernel_2d.kernel_support
+    gen_diffusion_timestep_euler_forward_pyst_mpi_kernel_2d.kernel_support = (
+        kernel_support
+    )
+    check_valid_ghost_size_and_kernel_support(
+        ghost_size=ghost_exchange_communicator.ghost_size,
+        kernel_support=gen_diffusion_timestep_euler_forward_pyst_mpi_kernel_2d.kernel_support,
+    )
+
+    def diffusion_timestep_euler_forward_pyst_mpi_kernel_2d(
+        field, diffusion_flux, nu_dt_by_dx2
+    ):
+        """2D Diffusion Euler forward timestep.
+
+        Performs an inplace diffusion timestep in 2D using Euler forward,
+        for a 2D field (n, n).
+        """
+        # define and store kernel support size
+        diffusion_timestep_euler_forward_pyst_mpi_kernel_2d.kernel_support = (
+            kernel_support
+        )
+        set_fixed_val_pyst_kernel_2d(field=diffusion_flux, fixed_val=0)
+        diffusion_flux_mpi_kernel_2d(
+            diffusion_flux=diffusion_flux,
+            field=field,
+            prefactor=nu_dt_by_dx2,
+        )
+        elementwise_sum_pyst_kernel_2d(
+            sum_field=field, field_1=field, field_2=diffusion_flux
+        )
+
+    return diffusion_timestep_euler_forward_pyst_mpi_kernel_2d

--- a/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_2d/diffusion_timestep_mpi_2d.py
+++ b/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_2d/diffusion_timestep_mpi_2d.py
@@ -46,7 +46,7 @@ def gen_diffusion_timestep_euler_forward_pyst_mpi_kernel_2d(
         """
         # define and store kernel support size
         diffusion_timestep_euler_forward_pyst_mpi_kernel_2d.kernel_support = (
-            kernel_support
+            gen_diffusion_flux_pyst_mpi_kernel_2d.kernel_support
         )
         set_fixed_val_pyst_kernel_2d(field=diffusion_flux, fixed_val=0)
         diffusion_flux_mpi_kernel_2d(

--- a/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_2d/diffusion_timestep_mpi_2d.py
+++ b/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_2d/diffusion_timestep_mpi_2d.py
@@ -1,5 +1,4 @@
 """MPI-supported kernels for performing diffusion timestep in 2D."""
-from tabnanny import check
 from sopht_mpi.numeric.eulerian_grid_ops.stencil_ops_2d.diffusion_flux_mpi_2d import (
     gen_diffusion_flux_pyst_mpi_kernel_2d,
 )

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_diffusion_timestep_mpi_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_diffusion_timestep_mpi_2d.py
@@ -82,7 +82,7 @@ def test_mpi_diffusion_timestep_2d(
         nu_dt_by_dx2=nu_dt_by_dx2,
     )
 
-    # gather back the diffusion flux globally
+    # gather back the field globally after diffusion timestep
     global_field = np.zeros_like(ref_field)
     gather_local_field(global_field, local_field, mpi_construct)
 

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_diffusion_timestep_mpi_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_diffusion_timestep_mpi_2d.py
@@ -1,0 +1,111 @@
+import numpy as np
+import pytest
+from sopht.utils.precision import get_real_t, get_test_tol
+from sopht.numeric.eulerian_grid_ops.stencil_ops_2d import (
+    gen_diffusion_timestep_euler_forward_pyst_kernel_2d,
+)
+from sopht_mpi.utils import (
+    MPIConstruct2D,
+    MPIGhostCommunicator2D,
+    MPIFieldCommunicator2D,
+)
+from sopht_mpi.numeric.eulerian_grid_ops.stencil_ops_2d import (
+    gen_diffusion_timestep_euler_forward_pyst_mpi_kernel_2d,
+)
+
+
+@pytest.mark.mpi(group="MPI_stencil_ops_2d")
+@pytest.mark.parametrize("ghost_size", [1, 2, 3])
+@pytest.mark.parametrize("precision", ["single", "double"])
+@pytest.mark.parametrize("rank_distribution", [(1, 0), (0, 1)])
+@pytest.mark.parametrize("aspect_ratio", [(1, 1), (1, 2), (2, 1)])
+def test_mpi_diffusion_timestep_2d(
+    ghost_size, precision, rank_distribution, aspect_ratio
+):
+    n_values = 64
+    real_t = get_real_t(precision)
+
+    # Generate the MPI topology minimal object
+    mpi_construct = MPIConstruct2D(
+        grid_size_y=n_values * aspect_ratio[1],
+        grid_size_x=n_values * aspect_ratio[0],
+        real_t=real_t,
+        rank_distribution=rank_distribution,
+    )
+
+    # extra width needed for kernel computation
+    mpi_ghost_exchange_communicator = MPIGhostCommunicator2D(
+        ghost_size=ghost_size, mpi_construct=mpi_construct
+    )
+    mpi_field_io_communicator = MPIFieldCommunicator2D(
+        ghost_size=ghost_size, mpi_construct=mpi_construct
+    )
+    gather_local_field = mpi_field_io_communicator.gather_local_field
+    scatter_global_field = mpi_field_io_communicator.scatter_global_field
+
+    # Allocate local field
+    local_field = np.zeros(
+        (
+            mpi_construct.local_grid_size[0] + 2 * ghost_size,
+            mpi_construct.local_grid_size[1] + 2 * ghost_size,
+        )
+    ).astype(real_t)
+    local_diffusion_flux = np.ones_like(local_field)
+
+    # Initialize and broadcast solution for comparison later
+    if mpi_construct.rank == 0:
+        ref_field = np.random.rand(
+            n_values * aspect_ratio[1], n_values * aspect_ratio[0]
+        ).astype(real_t)
+        nu_dt_by_dx2 = real_t(0.1)
+    else:
+        ref_field = None
+        nu_dt_by_dx2 = None
+    ref_field = mpi_construct.grid.bcast(ref_field, root=0)
+    nu_dt_by_dx2 = mpi_construct.grid.bcast(nu_dt_by_dx2, root=0)
+
+    # scatter global field
+    scatter_global_field(local_field, ref_field, mpi_construct)
+
+    # compute the diffusion timestep
+    diffusion_timestep_euler_forward_pyst_mpi_kernel = (
+        gen_diffusion_timestep_euler_forward_pyst_mpi_kernel_2d(
+            real_t=real_t,
+            mpi_construct=mpi_construct,
+            ghost_exchange_communicator=mpi_ghost_exchange_communicator,
+        )
+    )
+
+    diffusion_timestep_euler_forward_pyst_mpi_kernel(
+        diffusion_flux=local_diffusion_flux,
+        field=local_field,
+        nu_dt_by_dx2=nu_dt_by_dx2,
+    )
+
+    # gather back the diffusion flux globally
+    global_diffusion_flux = np.zeros_like(ref_field)
+    gather_local_field(global_diffusion_flux, local_diffusion_flux, mpi_construct)
+
+    # assert correct
+    if mpi_construct.rank == 0:
+        diffusion_timestep_euler_forward_pyst_kernel = (
+            gen_diffusion_timestep_euler_forward_pyst_kernel_2d(
+                real_t=real_t,
+            )
+        )
+        ref_diffusion_flux = np.zeros_like(ref_field)
+        diffusion_timestep_euler_forward_pyst_kernel(
+            diffusion_flux=ref_diffusion_flux,
+            field=ref_field,
+            nu_dt_by_dx2=nu_dt_by_dx2,
+        )
+        kernel_support = diffusion_timestep_euler_forward_pyst_mpi_kernel.kernel_support
+        # check kernel_support for the diffusion kernel
+        assert kernel_support == 1, "Incorrect kernel support!"
+        # check field correctness
+        inner_idx = (slice(kernel_support, -kernel_support),) * 2
+        np.testing.assert_allclose(
+            ref_diffusion_flux[inner_idx],
+            global_diffusion_flux[inner_idx],
+            atol=get_test_tol(precision),
+        )

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_diffusion_timestep_mpi_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_diffusion_timestep_mpi_2d.py
@@ -22,7 +22,7 @@ from sopht_mpi.numeric.eulerian_grid_ops.stencil_ops_2d import (
 def test_mpi_diffusion_timestep_2d(
     ghost_size, precision, rank_distribution, aspect_ratio
 ):
-    n_values = 64
+    n_values = 128
     real_t = get_real_t(precision)
 
     # Generate the MPI topology minimal object
@@ -83,8 +83,8 @@ def test_mpi_diffusion_timestep_2d(
     )
 
     # gather back the diffusion flux globally
-    global_diffusion_flux = np.zeros_like(ref_field)
-    gather_local_field(global_diffusion_flux, local_diffusion_flux, mpi_construct)
+    global_field = np.zeros_like(ref_field)
+    gather_local_field(global_field, local_field, mpi_construct)
 
     # assert correct
     if mpi_construct.rank == 0:
@@ -93,7 +93,7 @@ def test_mpi_diffusion_timestep_2d(
                 real_t=real_t,
             )
         )
-        ref_diffusion_flux = np.zeros_like(ref_field)
+        ref_diffusion_flux = np.ones_like(ref_field)
         diffusion_timestep_euler_forward_pyst_kernel(
             diffusion_flux=ref_diffusion_flux,
             field=ref_field,
@@ -105,7 +105,7 @@ def test_mpi_diffusion_timestep_2d(
         # check field correctness
         inner_idx = (slice(kernel_support, -kernel_support),) * 2
         np.testing.assert_allclose(
-            ref_diffusion_flux[inner_idx],
-            global_diffusion_flux[inner_idx],
+            ref_field[inner_idx],
+            global_field[inner_idx],
             atol=get_test_tol(precision),
         )


### PR DESCRIPTION
Fixes #14 

Note the slight additions with respect to `kernel_support` in generator function as well. Since the variables defined for a function can only be accessed after the function is called (otherwise that variable is never initialized in the first place), a workaround is to define `kernel_support` for generator function as well (see comments in `diffusion_timestep_mpi_2d.py`). That way, the generator and the generated function both have a consistent record of the kernel support they require, and it helps us keep track of it as well.