### PR TITLE
mpi brinkmann penalise 2d

### DIFF
--- a/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_2d/__init__.py
+++ b/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_2d/__init__.py
@@ -9,3 +9,4 @@ from .advection_timestep_mpi_2d import (
     gen_advection_timestep_euler_forward_conservative_eno3_pyst_mpi_kernel_2d,
 )
 from .outplane_field_curl_mpi_2d import gen_outplane_field_curl_pyst_mpi_kernel_2d
+from .brinkmann_penalise_mpi_2d import gen_brinkmann_penalise_pyst_mpi_kernel_2d

--- a/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_2d/brinkmann_penalise_mpi_2d.py
+++ b/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_2d/brinkmann_penalise_mpi_2d.py
@@ -6,59 +6,14 @@ from sopht.numeric.eulerian_grid_ops.stencil_ops_2d import (
 
 def gen_brinkmann_penalise_pyst_mpi_kernel_2d(real_t, field_type="scalar"):
     """MPI-supported Brinkmann penalisation 2D kernel generator."""
-    if field_type != "scalar" and field_type != "vector":
-        raise ValueError("Invalid field type")
-
     # define kernel support here, no need to check since kernel_support = 0
     # and ghost size is guaranteed to be >= 0 when ghost comm is created
     gen_brinkmann_penalise_pyst_mpi_kernel_2d.kernel_support = 0
-
-    if field_type == "scalar":
-        brinkmann_penalise_pyst_kernel_2d = gen_brinkmann_penalise_pyst_kernel_2d(
-            real_t=real_t,
-            field_type="scalar",
-        )
-
-        def brinkmann_penalise_scalar_field_pyst_mpi_kernel_2d(
-            penalised_field, penalty_factor, char_field, penalty_field, field
-        ):
-            """MPI-supported Brinkmann penalisation for 2D scalar field."""
-            brinkmann_penalise_scalar_field_pyst_mpi_kernel_2d.kernel_support = (
-                gen_brinkmann_penalise_pyst_mpi_kernel_2d.kernel_support
-            )
-            brinkmann_penalise_pyst_kernel_2d(
-                penalised_field=penalised_field,
-                penalty_factor=penalty_factor,
-                char_field=char_field,
-                penalty_field=penalty_field,
-                field=field,
-            )
-
-        return brinkmann_penalise_scalar_field_pyst_mpi_kernel_2d
-
-    elif field_type == "vector":
-        brinkmann_penalise_pyst_kernel_2d = gen_brinkmann_penalise_pyst_kernel_2d(
-            real_t=real_t,
-            field_type="vector",
-        )
-
-        def brinkmann_penalise_vector_field_pyst_mpi_kernel_2d(
-            penalised_vector_field,
-            penalty_factor,
-            char_field,
-            penalty_vector_field,
-            vector_field,
-        ):
-            """MPI-supported Brinkmann penalisation for 2D vector field."""
-            brinkmann_penalise_vector_field_pyst_mpi_kernel_2d.kernel_support = (
-                gen_brinkmann_penalise_pyst_mpi_kernel_2d.kernel_support
-            )
-            brinkmann_penalise_pyst_kernel_2d(
-                penalised_vector_field=penalised_vector_field,
-                penalty_factor=penalty_factor,
-                char_field=char_field,
-                penalty_vector_field=penalty_vector_field,
-                vector_field=vector_field,
-            )
-
-        return brinkmann_penalise_vector_field_pyst_mpi_kernel_2d
+    brinkmann_penalise_pyst_mpi_kernel_2d = gen_brinkmann_penalise_pyst_kernel_2d(
+        real_t=real_t,
+        field_type=field_type,
+    )
+    brinkmann_penalise_pyst_mpi_kernel_2d.kernel_support = (
+        gen_brinkmann_penalise_pyst_mpi_kernel_2d.kernel_support
+    )
+    return brinkmann_penalise_pyst_mpi_kernel_2d

--- a/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_2d/brinkmann_penalise_mpi_2d.py
+++ b/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_2d/brinkmann_penalise_mpi_2d.py
@@ -2,7 +2,6 @@
 from sopht.numeric.eulerian_grid_ops.stencil_ops_2d import (
     gen_brinkmann_penalise_pyst_kernel_2d,
 )
-from sopht_mpi.utils.mpi_utils import check_valid_ghost_size_and_kernel_support
 
 
 def gen_brinkmann_penalise_pyst_mpi_kernel_2d(real_t, field_type="scalar"):

--- a/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_2d/brinkmann_penalise_mpi_2d.py
+++ b/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_2d/brinkmann_penalise_mpi_2d.py
@@ -1,0 +1,65 @@
+"""MPI-supported kernels for Brinkmann penalisation in 2D."""
+from sopht.numeric.eulerian_grid_ops.stencil_ops_2d import (
+    gen_brinkmann_penalise_pyst_kernel_2d,
+)
+from sopht_mpi.utils.mpi_utils import check_valid_ghost_size_and_kernel_support
+
+
+def gen_brinkmann_penalise_pyst_mpi_kernel_2d(real_t, field_type="scalar"):
+    """MPI-supported Brinkmann penalisation 2D kernel generator."""
+    if field_type != "scalar" and field_type != "vector":
+        raise ValueError("Invalid field type")
+
+    # define kernel support here, no need to check since kernel_support = 0
+    # and ghost size is guaranteed to be >= 0 when ghost comm is created
+    gen_brinkmann_penalise_pyst_mpi_kernel_2d.kernel_support = 0
+
+    if field_type == "scalar":
+        brinkmann_penalise_pyst_kernel_2d = gen_brinkmann_penalise_pyst_kernel_2d(
+            real_t=real_t,
+            field_type="scalar",
+        )
+
+        def brinkmann_penalise_scalar_field_pyst_mpi_kernel_2d(
+            penalised_field, penalty_factor, char_field, penalty_field, field
+        ):
+            """MPI-supported Brinkmann penalisation for 2D scalar field."""
+            brinkmann_penalise_scalar_field_pyst_mpi_kernel_2d.kernel_support = (
+                gen_brinkmann_penalise_pyst_mpi_kernel_2d.kernel_support
+            )
+            brinkmann_penalise_pyst_kernel_2d(
+                penalised_field=penalised_field,
+                penalty_factor=penalty_factor,
+                char_field=char_field,
+                penalty_field=penalty_field,
+                field=field,
+            )
+
+        return brinkmann_penalise_scalar_field_pyst_mpi_kernel_2d
+
+    elif field_type == "vector":
+        brinkmann_penalise_pyst_kernel_2d = gen_brinkmann_penalise_pyst_kernel_2d(
+            real_t=real_t,
+            field_type="vector",
+        )
+
+        def brinkmann_penalise_vector_field_pyst_mpi_kernel_2d(
+            penalised_vector_field,
+            penalty_factor,
+            char_field,
+            penalty_vector_field,
+            vector_field,
+        ):
+            """MPI-supported Brinkmann penalisation for 2D vector field."""
+            brinkmann_penalise_vector_field_pyst_mpi_kernel_2d.kernel_support = (
+                gen_brinkmann_penalise_pyst_mpi_kernel_2d.kernel_support
+            )
+            brinkmann_penalise_pyst_kernel_2d(
+                penalised_vector_field=penalised_vector_field,
+                penalty_factor=penalty_factor,
+                char_field=char_field,
+                penalty_vector_field=penalty_vector_field,
+                vector_field=vector_field,
+            )
+
+        return brinkmann_penalise_vector_field_pyst_mpi_kernel_2d

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_brinkmann_penalise_mpi_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_brinkmann_penalise_mpi_2d.py
@@ -1,0 +1,240 @@
+import numpy as np
+import pytest
+from sopht.utils.precision import get_real_t, get_test_tol
+from sopht.numeric.eulerian_grid_ops.stencil_ops_2d import (
+    gen_brinkmann_penalise_pyst_kernel_2d,
+)
+from sopht_mpi.utils import (
+    MPIConstruct2D,
+    MPIGhostCommunicator2D,
+    MPIFieldCommunicator2D,
+)
+from sopht_mpi.numeric.eulerian_grid_ops.stencil_ops_2d import (
+    gen_brinkmann_penalise_pyst_mpi_kernel_2d,
+)
+
+
+@pytest.mark.mpi(group="MPI_stencil_ops_2d", min_size=2)
+@pytest.mark.parametrize("ghost_size", [0, 1, 2, 3])
+@pytest.mark.parametrize("precision", ["single", "double"])
+@pytest.mark.parametrize("rank_distribution", [(1, 0), (0, 1)])
+@pytest.mark.parametrize("aspect_ratio", [(1, 1), (1, 2), (2, 1)])
+def test_mpi_brinkmann_penalise_scalar_field_2d(
+    ghost_size, precision, rank_distribution, aspect_ratio
+):
+    n_values = 32
+    real_t = get_real_t(precision)
+    # Generate the MPI topology minimal object
+    mpi_construct = MPIConstruct2D(
+        grid_size_y=n_values * aspect_ratio[0],
+        grid_size_x=n_values * aspect_ratio[1],
+        real_t=real_t,
+        rank_distribution=rank_distribution,
+    )
+
+    # Initialize field communicator
+    # No need for ghost communicator, since no ghost exchange is needed
+    mpi_field_io_communicator = MPIFieldCommunicator2D(
+        ghost_size=ghost_size, mpi_construct=mpi_construct
+    )
+    gather_local_field = mpi_field_io_communicator.gather_local_field
+    scatter_global_field = mpi_field_io_communicator.scatter_global_field
+
+    # Allocate local field
+    local_field = np.zeros(
+        (
+            mpi_construct.local_grid_size[0] + 2 * ghost_size,
+            mpi_construct.local_grid_size[1] + 2 * ghost_size,
+        )
+    ).astype(real_t)
+    local_penalty_field = np.zeros_like(local_field)
+    local_char_field = np.zeros_like(local_field)
+    local_penalised_field = np.zeros_like(local_field)
+
+    # Initialize and broadcast solution for comparison later
+    if mpi_construct.rank == 0:
+        ref_field = np.random.rand(
+            n_values * aspect_ratio[0], n_values * aspect_ratio[1]
+        ).astype(real_t)
+        ref_penalty_field = np.random.rand(
+            n_values * aspect_ratio[0], n_values * aspect_ratio[1]
+        ).astype(real_t)
+        ref_char_field = np.random.rand(
+            n_values * aspect_ratio[0], n_values * aspect_ratio[1]
+        ).astype(real_t)
+        penalty_factor = real_t(0.1)
+    else:
+        ref_field = None
+        ref_penalty_field = None
+        ref_char_field = None
+        penalty_factor = None
+    ref_field = mpi_construct.grid.bcast(ref_field, root=0)
+    ref_penalty_field = mpi_construct.grid.bcast(ref_penalty_field, root=0)
+    ref_char_field = mpi_construct.grid.bcast(ref_char_field, root=0)
+    penalty_factor = mpi_construct.grid.bcast(penalty_factor, root=0)
+
+    # scatter global field
+    scatter_global_field(local_field, ref_field, mpi_construct)
+    scatter_global_field(local_penalty_field, ref_penalty_field, mpi_construct)
+    scatter_global_field(local_char_field, ref_char_field, mpi_construct)
+
+    # compute the brinkmann penalisation
+    brinkmann_penalise_scalar_field_pyst_mpi_kernel = (
+        gen_brinkmann_penalise_pyst_mpi_kernel_2d(real_t=real_t, field_type="scalar")
+    )
+
+    brinkmann_penalise_scalar_field_pyst_mpi_kernel(
+        penalised_field=local_penalised_field,
+        penalty_factor=penalty_factor,
+        char_field=local_char_field,
+        penalty_field=local_penalty_field,
+        field=local_field,
+    )
+
+    # gather back the field globally after diffusion timestep
+    global_penalised_field = np.zeros_like(ref_field)
+    gather_local_field(global_penalised_field, local_penalised_field, mpi_construct)
+
+    # assert correct
+    if mpi_construct.rank == 0:
+        brinkmann_penalise_pyst_kernel = gen_brinkmann_penalise_pyst_kernel_2d(
+            real_t=real_t, field_type="scalar"
+        )
+        ref_penalised_field = np.ones_like(ref_field)
+        brinkmann_penalise_pyst_kernel(
+            penalised_field=ref_penalised_field,
+            penalty_factor=penalty_factor,
+            char_field=ref_char_field,
+            penalty_field=ref_penalty_field,
+            field=ref_field,
+        )
+        kernel_support = brinkmann_penalise_scalar_field_pyst_mpi_kernel.kernel_support
+        # check kernel_support for the diffusion kernel
+        assert kernel_support == 0, "Incorrect kernel support!"
+        # check field correctness
+        inner_idx = (slice(kernel_support, -kernel_support),) * 2
+        np.testing.assert_allclose(
+            ref_penalised_field[inner_idx],
+            global_penalised_field[inner_idx],
+            atol=get_test_tol(precision),
+        )
+
+
+@pytest.mark.mpi(group="MPI_stencil_ops_2d", min_size=2)
+@pytest.mark.parametrize("ghost_size", [0, 1, 2, 3])
+@pytest.mark.parametrize("precision", ["single", "double"])
+@pytest.mark.parametrize("rank_distribution", [(1, 0), (0, 1)])
+@pytest.mark.parametrize("aspect_ratio", [(1, 1), (1, 2), (2, 1)])
+def test_mpi_brinkmann_penalise_vector_field_2d(
+    ghost_size, precision, rank_distribution, aspect_ratio
+):
+    n_values = 32
+    real_t = get_real_t(precision)
+    # Generate the MPI topology minimal object
+    mpi_construct = MPIConstruct2D(
+        grid_size_y=n_values * aspect_ratio[0],
+        grid_size_x=n_values * aspect_ratio[1],
+        real_t=real_t,
+        rank_distribution=rank_distribution,
+    )
+
+    # Initialize field communicator
+    # No need for ghost communicator, since no ghost exchange is needed
+    mpi_field_io_communicator = MPIFieldCommunicator2D(
+        ghost_size=ghost_size, mpi_construct=mpi_construct
+    )
+    gather_local_field = mpi_field_io_communicator.gather_local_field
+    scatter_global_field = mpi_field_io_communicator.scatter_global_field
+
+    # Allocate local field
+    local_vector_field = np.zeros(
+        (
+            2,
+            mpi_construct.local_grid_size[0] + 2 * ghost_size,
+            mpi_construct.local_grid_size[1] + 2 * ghost_size,
+        )
+    ).astype(real_t)
+    local_penalty_vector_field = np.zeros_like(local_vector_field)
+    local_char_field = np.zeros_like(local_vector_field[0])
+    local_penalised_vector_field = np.zeros_like(local_vector_field)
+
+    # Initialize and broadcast solution for comparison later
+    if mpi_construct.rank == 0:
+        ref_vector_field = np.random.rand(
+            2, n_values * aspect_ratio[0], n_values * aspect_ratio[1]
+        ).astype(real_t)
+        ref_penalty_vector_field = np.random.rand(
+            2, n_values * aspect_ratio[0], n_values * aspect_ratio[1]
+        ).astype(real_t)
+        ref_char_field = np.random.rand(
+            n_values * aspect_ratio[0], n_values * aspect_ratio[1]
+        ).astype(real_t)
+        penalty_factor = real_t(0.1)
+    else:
+        ref_vector_field = None
+        ref_penalty_vector_field = None
+        ref_char_field = None
+        penalty_factor = None
+    ref_vector_field = mpi_construct.grid.bcast(ref_vector_field, root=0)
+    ref_penalty_vector_field = mpi_construct.grid.bcast(
+        ref_penalty_vector_field, root=0
+    )
+    ref_char_field = mpi_construct.grid.bcast(ref_char_field, root=0)
+    penalty_factor = mpi_construct.grid.bcast(penalty_factor, root=0)
+
+    # scatter global field
+    scatter_global_field(local_vector_field[0], ref_vector_field[0], mpi_construct)
+    scatter_global_field(local_vector_field[1], ref_vector_field[1], mpi_construct)
+    scatter_global_field(
+        local_penalty_vector_field[0], ref_penalty_vector_field[0], mpi_construct
+    )
+    scatter_global_field(
+        local_penalty_vector_field[1], ref_penalty_vector_field[1], mpi_construct
+    )
+    scatter_global_field(local_char_field, ref_char_field, mpi_construct)
+
+    # compute the brinkmann penalisation
+    brinkmann_penalise_vector_field_pyst_mpi_kernel = (
+        gen_brinkmann_penalise_pyst_mpi_kernel_2d(real_t=real_t, field_type="vector")
+    )
+
+    brinkmann_penalise_vector_field_pyst_mpi_kernel(
+        penalised_vector_field=local_penalised_vector_field,
+        penalty_factor=penalty_factor,
+        char_field=local_char_field,
+        penalty_vector_field=local_penalty_vector_field,
+        vector_field=local_vector_field,
+    )
+
+    # gather back the vector field globally after diffusion timestep
+    global_penalised_vector_field = np.zeros_like(ref_vector_field)
+    gather_local_field(
+        global_penalised_vector_field[0], local_penalised_vector_field[0], mpi_construct
+    )
+    gather_local_field(
+        global_penalised_vector_field[1], local_penalised_vector_field[1], mpi_construct
+    )
+
+    # assert correct
+    if mpi_construct.rank == 0:
+        brinkmann_penalise_pyst_kernel = gen_brinkmann_penalise_pyst_kernel_2d(
+            real_t=real_t, field_type="vector"
+        )
+        ref_penalised_vector_field = np.ones_like(ref_vector_field)
+        brinkmann_penalise_pyst_kernel(
+            penalised_vector_field=ref_penalised_vector_field,
+            penalty_factor=penalty_factor,
+            char_field=ref_char_field,
+            penalty_vector_field=ref_penalty_vector_field,
+            vector_field=ref_vector_field,
+        )
+        kernel_support = brinkmann_penalise_vector_field_pyst_mpi_kernel.kernel_support
+        # check kernel_support for the diffusion kernel
+        assert kernel_support == 0, "Incorrect kernel support!"
+        # check field correctness
+        inner_idx = (slice(kernel_support, -kernel_support),) * 2
+        np.testing.assert_allclose(
+            ref_penalised_vector_field[inner_idx],
+            global_penalised_vector_field[inner_idx],
+            atol=get_test_tol(precision),
+        )

--- a/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_brinkmann_penalise_mpi_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_stencil_ops_2d/test_brinkmann_penalise_mpi_2d.py
@@ -4,11 +4,7 @@ from sopht.utils.precision import get_real_t, get_test_tol
 from sopht.numeric.eulerian_grid_ops.stencil_ops_2d import (
     gen_brinkmann_penalise_pyst_kernel_2d,
 )
-from sopht_mpi.utils import (
-    MPIConstruct2D,
-    MPIGhostCommunicator2D,
-    MPIFieldCommunicator2D,
-)
+from sopht_mpi.utils import MPIConstruct2D, MPIFieldCommunicator2D
 from sopht_mpi.numeric.eulerian_grid_ops.stencil_ops_2d import (
     gen_brinkmann_penalise_pyst_mpi_kernel_2d,
 )


### PR DESCRIPTION
Fixes #22 

@bhosale2 So this kernel basically has `kernel_support=0`, so no ghosting/communication is needed for this operation, and MPI-related stuff is not quite needed. Nonetheless, for consistency in the mpi-version of sopht (and perhaps also for how we are already storing `kernel_support` for each generated kernel), I feel perhaps we should still have it anyway so I went ahead and implemented a working version here. Please let me know what you think and we can discuss/decide from there.
If we decide to keep this, then one minor thing I noticed is, the `field_type` check is done twice, once in the MPI kernel gen, and another time in the non-mpi kernel gen in sopht-backend, mainly because the generated function argument names are slightly different depending on `field_type` (i.e. `field` vs. `vector_field`). Don't think this affects performance tho, since kernel generation is done once I think?

Also, depending on what we do here, we will probably do the same for other kernels with `kernel_support = 0`.