### PR TITLE
mpi unbounded poisson solve 2d

### DIFF
--- a/sopht_mpi/numeric/eulerian_grid_ops/poisson_solver_2d/UnboundedPoissonSolverMPI2D.py
+++ b/sopht_mpi/numeric/eulerian_grid_ops/poisson_solver_2d/UnboundedPoissonSolverMPI2D.py
@@ -64,13 +64,11 @@ class UnboundedPoissonSolverMPI2D:
         y_axis = 0
         x_axis = 1
 
-        # define local xy-coord mesh
-        local_x_grid = newDistArray(pfft=self.fft_construct.fft, forward_output=False)
-        local_y_grid = newDistArray(pfft=self.fft_construct.fft, forward_output=False)
-
         # get start and end indices of local grid relative to global grid
-        global_start_idx = np.array(local_x_grid.substart)
-        local_grid_size = local_x_grid.shape
+        # this information is stored in domain_doubled_buffer, which a distarray
+        # initialized in FFTMPI2D
+        global_start_idx = np.array(self.domain_doubled_buffer.substart)
+        local_grid_size = self.domain_doubled_buffer.shape
         global_end_idx = global_start_idx + local_grid_size
 
         # Generate local xy mesh based on local grid location

--- a/sopht_mpi/numeric/eulerian_grid_ops/poisson_solver_2d/UnboundedPoissonSolverMPI2D.py
+++ b/sopht_mpi/numeric/eulerian_grid_ops/poisson_solver_2d/UnboundedPoissonSolverMPI2D.py
@@ -1,0 +1,346 @@
+"""MPI-supported unbounded Poisson solver kernels 2D via mpi4py-fft."""
+import numpy as np
+from mpi4py import MPI
+from mpi4py_fft import newDistArray
+from sopht.numeric.eulerian_grid_ops.stencil_ops_2d.elementwise_ops_2d import (
+    gen_elementwise_complex_product_pyst_kernel_2d,
+    gen_set_fixed_val_pyst_kernel_2d,
+)
+from sopht_mpi.numeric.eulerian_grid_ops.poisson_solver_2d.fft_mpi_2d import FFTMPI2D
+
+
+class UnboundedPoissonSolverMPI2D:
+    """
+    MPI-supported class for solving unbounded Poisson in 2D via mpi4py-fft.
+
+    Note: We need ghost size here to maintain contiguous memory when passing in
+    local fields with ghost cells for poisson solve.
+    """
+
+    def __init__(
+        self,
+        grid_size_y,
+        grid_size_x,
+        mpi_construct,
+        ghost_size,
+        x_range=1.0,
+        real_t=np.float64,
+    ):
+        """Class initialiser."""
+        self.mpi_construct = mpi_construct
+        self.grid_size_y = grid_size_y
+        self.grid_size_x = grid_size_x
+        self.x_range = x_range
+        self.y_range = x_range * (grid_size_y / grid_size_x)
+        self.dx = real_t(x_range / grid_size_x)
+        self.real_t = real_t
+        self.mpi_domain_doubling_comm = MPIDomainDoublingCommunicator2D(
+            ghost_size=ghost_size, mpi_construct=self.mpi_construct
+        )
+
+        self.fft_construct = FFTMPI2D(
+            # 2 because FFTs taken on doubled domain
+            grid_size_y=2 * grid_size_y,
+            grid_size_x=2 * grid_size_x,
+            mpi_construct=mpi_construct,
+            real_t=real_t,
+        )
+        self.rfft = self.fft_construct.forward
+        self.irfft = self.fft_construct.backward
+        self.domain_doubled_buffer = self.fft_construct.field_buffer
+        self.domain_doubled_fourier_buffer = self.fft_construct.fourier_field_buffer
+        self.convolution_buffer = newDistArray(
+            pfft=self.fft_construct.fft, forward_output=True
+        )
+        self.construct_fourier_greens_function_field()
+        self.fourier_greens_function_times_dx_squared = (
+            self.domain_doubled_fourier_buffer * (self.dx**2)
+        )
+        self.gen_elementwise_operation_kernels()
+
+    def construct_fourier_greens_function_field(self):
+        """Construct the local grid of unbounded Greens function."""
+        # Lines below to make code more literal
+        y_axis = 0
+        x_axis = 1
+
+        # define local xy-coord mesh
+        local_x_grid = newDistArray(pfft=self.fft_construct.fft, forward_output=False)
+        local_y_grid = newDistArray(pfft=self.fft_construct.fft, forward_output=False)
+
+        # get start and end indices of local grid relative to global grid
+        global_start_idx = np.array(local_x_grid.substart)
+        local_grid_size = local_x_grid.shape
+        global_end_idx = global_start_idx + local_grid_size
+
+        # Generate local xy mesh based on local grid location
+        local_x = np.linspace(
+            global_start_idx[x_axis] * self.dx,
+            (global_end_idx[x_axis] - 1) * self.dx,
+            local_grid_size[x_axis],
+        ).astype(self.real_t)
+        local_y = np.linspace(
+            global_start_idx[y_axis] * self.dx,
+            (global_end_idx[y_axis] - 1) * self.dx,
+            local_grid_size[y_axis],
+        ).astype(self.real_t)
+        local_x_grid, local_y_grid = np.meshgrid(local_x, local_y)
+
+        # Generate greens function field
+        even_reflected_distance_field = np.sqrt(
+            np.minimum(local_x_grid, 2 * self.x_range - local_x_grid) ** 2
+            + np.minimum(local_y_grid, 2 * self.y_range - local_y_grid) ** 2
+        )
+        greens_function_field = newDistArray(
+            pfft=self.fft_construct.fft, forward_output=False
+        )
+        with np.errstate(divide="ignore", invalid="ignore", over="ignore"):
+            greens_function_field = -np.log(even_reflected_distance_field) / (2 * np.pi)
+        # Regularization term
+        if np.all(global_start_idx == 0):
+            greens_function_field[0, 0] = -(
+                2 * np.log(self.dx / np.sqrt(np.pi)) - 1
+            ) / (4 * np.pi)
+
+        # take forward transform of greens function field
+        self.rfft(
+            field=greens_function_field,
+            fourier_field=self.domain_doubled_fourier_buffer,
+        )
+
+    def gen_elementwise_operation_kernels(self):
+        """Compile funcs for elementwise ops on buffers."""
+        # this operate on domain doubled arrays
+        self.set_fixed_val_kernel_2d = gen_set_fixed_val_pyst_kernel_2d(
+            real_t=self.real_t
+        )
+        # this one operates on fourier buffer
+        self.elementwise_complex_product_kernel_2d = (
+            gen_elementwise_complex_product_pyst_kernel_2d(real_t=self.real_t)
+        )
+
+    def solve(self, solution_field, rhs_field):
+        """Unbounded Poisson solver method.
+        Solves Poisson equation in 2D: -del^2(solution_field) = rhs_field
+        for unbounded domain using Greens function convolution and
+        domain doubling trick (Hockney and Eastwood).
+        """
+
+        self.set_fixed_val_kernel_2d(field=self.domain_doubled_buffer, fixed_val=0)
+        self.mpi_domain_doubling_comm.copy_to_doubled_domain(
+            local_field=rhs_field,
+            local_doubled_field=self.domain_doubled_buffer,
+        )
+
+        self.rfft(
+            field=self.domain_doubled_buffer,
+            fourier_field=self.domain_doubled_fourier_buffer,
+        )
+
+        # Greens function convolution
+        self.elementwise_complex_product_kernel_2d(
+            product_field=self.convolution_buffer,
+            field_1=self.domain_doubled_fourier_buffer,
+            field_2=self.fourier_greens_function_times_dx_squared,
+        )
+
+        self.irfft(
+            fourier_field=self.convolution_buffer,
+            inv_fourier_field=self.domain_doubled_buffer,
+        )
+
+        self.mpi_domain_doubling_comm.copy_from_doubled_domain(
+            local_doubled_field=self.domain_doubled_buffer,
+            local_field=solution_field,
+        )
+
+
+class MPIDomainDoublingCommunicator2D:
+    """
+    Class exclusive for field communication between actual and doubled domain.
+    Since mpi4py-fft always require that at least one axis of a multidimensional
+    array remains aligned (non-distributed), in 2D that translates to slab
+    decomposition, which will be assumed for the communication operations here.
+    """
+
+    def __init__(self, ghost_size, mpi_construct):
+        self.mpi_construct = mpi_construct
+        # Use ghost_size to define offset indices for inner cell
+        if ghost_size < 0 and not isinstance(ghost_size, int):
+            raise ValueError(
+                f"Ghost size {ghost_size} needs to be an integer >= 0"
+                "for field communication."
+            )
+        self.ghost_size = ghost_size
+
+        # define grid sizes for actual and doubled domain
+        self.field_sub_size = mpi_construct.local_grid_size
+        self.field_doubled_sub_size = mpi_construct.local_grid_size * 2
+
+        distributed_dim = np.where(np.array(mpi_construct.grid_topology) != 1)[0]
+        if len(distributed_dim) > 1:
+            raise ValueError(
+                f"Distributed in {len(distributed_dim)} dimensions."
+                "Only 1 dimension is allowed to be distributed in 2D (slab decomp)"
+            )
+        self.distributed_dim = distributed_dim[0]
+        # Copying from actual to doubled domain -> two receives, one send
+        # Copying from doubled to actual domain -> two sends, one receive
+        # Total requests needed = 3 requests
+        self.num_requests = 3
+        self.comm_requests = [
+            0,
+        ] * self.num_requests
+
+        # communication datatypes initialization
+        # (1) Buffers for actual -> doubled domain communication
+        # For sending from actual domain. Local actual domain contains ghost cells
+        starts = [self.ghost_size] * mpi_construct.grid_dim
+        self.send_from_actual_to_doubled_domain_type = (
+            self.mpi_construct.dtype_generator.Create_subarray(
+                sizes=self.field_sub_size + 2 * self.ghost_size,
+                subsizes=self.field_sub_size,
+                starts=starts,
+            )
+        )
+        self.send_from_actual_to_doubled_domain_type.Commit()
+        # For recving into doubled domain, one each for (a) first and (b) second
+        # half of the doubled block of data in doubled domain
+        # (a) First half (start offset assumes slab decomp)
+        starts = [0] * mpi_construct.grid_dim
+        self.recv_from_actual_to_doubled_domain_first_half_type = (
+            self.mpi_construct.dtype_generator.Create_subarray(
+                sizes=self.field_doubled_sub_size,
+                subsizes=self.field_sub_size,
+                starts=starts,
+            )
+        )
+        self.recv_from_actual_to_doubled_domain_first_half_type.Commit()
+        # (b) Second half (start offset assumes slab decomp)
+        starts = [0, 0]
+        starts[self.distributed_dim] = self.field_sub_size[self.distributed_dim]
+        self.recv_from_actual_to_doubled_domain_second_half_type = (
+            self.mpi_construct.dtype_generator.Create_subarray(
+                sizes=self.field_doubled_sub_size,
+                subsizes=self.field_sub_size,
+                starts=starts,
+            )
+        )
+        self.recv_from_actual_to_doubled_domain_second_half_type.Commit()
+
+        # (2) Buffers for doubled -> actual domain communication
+        # For sending from doubled domain, one each for (a) first and (b) second
+        # half of the doubled block of data in doubled domain
+        # (a) First half (start offset assumes slab decomp)
+        starts = [0] * mpi_construct.grid_dim
+        self.send_from_doubled_to_actual_domain_first_half_type = (
+            self.mpi_construct.dtype_generator.Create_subarray(
+                sizes=self.field_doubled_sub_size,
+                subsizes=self.field_sub_size,
+                starts=starts,
+            )
+        )
+        self.send_from_doubled_to_actual_domain_first_half_type.Commit()
+        # (b) Second half (start offset assumes slab decomp)
+        starts = [0, 0]
+        starts[self.distributed_dim] = self.field_sub_size[self.distributed_dim]
+        self.send_from_doubled_to_actual_domain_second_half_type = (
+            self.mpi_construct.dtype_generator.Create_subarray(
+                sizes=self.field_doubled_sub_size,
+                subsizes=self.field_sub_size,
+                starts=starts,
+            )
+        )
+        self.send_from_doubled_to_actual_domain_second_half_type.Commit()
+
+        # For recving into actual domain. Local actual domain contains ghost cells
+        starts = [self.ghost_size] * mpi_construct.grid_dim
+        self.recv_from_doubled_to_actual_domain_type = (
+            self.mpi_construct.dtype_generator.Create_subarray(
+                sizes=self.field_sub_size + 2 * self.ghost_size,
+                subsizes=self.field_sub_size,
+                starts=starts,
+            )
+        )
+        self.recv_from_doubled_to_actual_domain_type.Commit()
+
+    def copy_to_doubled_domain(self, local_field, local_doubled_field):
+        """
+        One send for each rank from actual domain,
+        two receives for each rank in doubled domain.
+        """
+        coord = self.mpi_construct.grid.coords[self.distributed_dim]
+        send_offset = coord // 2 + coord % 2
+        dest = self.mpi_construct.grid.Shift(self.distributed_dim, send_offset)[0]
+        self.comm_requests[0] = self.mpi_construct.grid.Isend(
+            (local_field, self.send_from_actual_to_doubled_domain_type),
+            dest=dest,
+        )
+        if coord < self.mpi_construct.grid_topology[self.distributed_dim] / 2:
+            recv_offset_first_half = 2 * coord - coord
+            source_first_half = self.mpi_construct.grid.Shift(
+                self.distributed_dim, recv_offset_first_half
+            )[1]
+            self.comm_requests[1] = self.mpi_construct.grid.Irecv(
+                (
+                    local_doubled_field,
+                    self.recv_from_actual_to_doubled_domain_first_half_type,
+                ),
+                source=source_first_half,
+            )
+            recv_offset_second_half = 2 * coord + 1 - coord
+            source_second_half = self.mpi_construct.grid.Shift(
+                self.distributed_dim, recv_offset_second_half
+            )[1]
+            self.comm_requests[2] = self.mpi_construct.grid.Irecv(
+                (
+                    local_doubled_field,
+                    self.recv_from_actual_to_doubled_domain_second_half_type,
+                ),
+                source=source_second_half,
+            )
+        else:
+            self.comm_requests[1] = MPI.REQUEST_NULL
+            self.comm_requests[2] = MPI.REQUEST_NULL
+
+        MPI.Request.Waitall(self.comm_requests)
+
+    def copy_from_doubled_domain(self, local_doubled_field, local_field):
+        """
+        Two sends for each rank from doubled domain,
+        one receive for each rank in actual domain.
+        """
+        coord = self.mpi_construct.grid.coords[self.distributed_dim]
+        if coord < self.mpi_construct.grid_topology[self.distributed_dim] / 2:
+            send_offset_first_half = 2 * coord - coord
+            dest_first_half = self.mpi_construct.grid.Shift(
+                self.distributed_dim, send_offset_first_half
+            )[1]
+            self.comm_requests[0] = self.mpi_construct.grid.Isend(
+                (
+                    local_doubled_field,
+                    self.send_from_doubled_to_actual_domain_first_half_type,
+                ),
+                dest=dest_first_half,
+            )
+            send_offset_second_half = 2 * coord + 1 - coord
+            dest_second_half = self.mpi_construct.grid.Shift(
+                self.distributed_dim, send_offset_second_half
+            )[1]
+            self.comm_requests[1] = self.mpi_construct.grid.Isend(
+                (
+                    local_doubled_field,
+                    self.send_from_doubled_to_actual_domain_second_half_type,
+                ),
+                dest=dest_second_half,
+            )
+        else:
+            self.comm_requests[0] = MPI.REQUEST_NULL
+            self.comm_requests[1] = MPI.REQUEST_NULL
+        recv_offset = coord // 2 + coord % 2
+        source = self.mpi_construct.grid.Shift(self.distributed_dim, recv_offset)[0]
+        self.comm_requests[2] = self.mpi_construct.grid.Irecv(
+            (local_field, self.recv_from_doubled_to_actual_domain_type),
+            source=source,
+        )
+        MPI.Request.Waitall(self.comm_requests)

--- a/sopht_mpi/numeric/eulerian_grid_ops/poisson_solver_2d/UnboundedPoissonSolverMPI2D.py
+++ b/sopht_mpi/numeric/eulerian_grid_ops/poisson_solver_2d/UnboundedPoissonSolverMPI2D.py
@@ -159,6 +159,8 @@ class MPIDomainDoublingCommunicator2D:
     Since mpi4py-fft always require that at least one axis of a multidimensional
     array remains aligned (non-distributed), in 2D that translates to slab
     decomposition, which will be assumed for the communication operations here.
+
+    TODO: An illustration of the communication pattern is needed for clarity
     """
 
     def __init__(self, ghost_size, mpi_construct):

--- a/sopht_mpi/numeric/eulerian_grid_ops/poisson_solver_2d/UnboundedPoissonSolverMPI2D.py
+++ b/sopht_mpi/numeric/eulerian_grid_ops/poisson_solver_2d/UnboundedPoissonSolverMPI2D.py
@@ -173,9 +173,9 @@ class MPIDomainDoublingCommunicator2D:
             )
         self.ghost_size = ghost_size
 
-        # define grid sizes for actual and doubled domain
-        self.field_sub_size = mpi_construct.local_grid_size
-        self.field_doubled_sub_size = mpi_construct.local_grid_size * 2
+        # define local grid sizes for actual and doubled domain
+        self.field_grid_size = mpi_construct.local_grid_size
+        self.field_doubled_grid_size = mpi_construct.local_grid_size * 2
 
         distributed_dim = np.where(np.array(mpi_construct.grid_topology) != 1)[0]
         if len(distributed_dim) > 1:
@@ -198,8 +198,8 @@ class MPIDomainDoublingCommunicator2D:
         starts = [self.ghost_size] * mpi_construct.grid_dim
         self.send_from_actual_to_doubled_domain_type = (
             self.mpi_construct.dtype_generator.Create_subarray(
-                sizes=self.field_sub_size + 2 * self.ghost_size,
-                subsizes=self.field_sub_size,
+                sizes=self.field_grid_size + 2 * self.ghost_size,
+                subsizes=self.field_grid_size,
                 starts=starts,
             )
         )
@@ -210,19 +210,19 @@ class MPIDomainDoublingCommunicator2D:
         starts = [0] * mpi_construct.grid_dim
         self.recv_from_actual_to_doubled_domain_first_half_type = (
             self.mpi_construct.dtype_generator.Create_subarray(
-                sizes=self.field_doubled_sub_size,
-                subsizes=self.field_sub_size,
+                sizes=self.field_doubled_grid_size,
+                subsizes=self.field_grid_size,
                 starts=starts,
             )
         )
         self.recv_from_actual_to_doubled_domain_first_half_type.Commit()
         # (b) Second half (start offset assumes slab decomp)
         starts = [0, 0]
-        starts[self.distributed_dim] = self.field_sub_size[self.distributed_dim]
+        starts[self.distributed_dim] = self.field_grid_size[self.distributed_dim]
         self.recv_from_actual_to_doubled_domain_second_half_type = (
             self.mpi_construct.dtype_generator.Create_subarray(
-                sizes=self.field_doubled_sub_size,
-                subsizes=self.field_sub_size,
+                sizes=self.field_doubled_grid_size,
+                subsizes=self.field_grid_size,
                 starts=starts,
             )
         )
@@ -235,19 +235,19 @@ class MPIDomainDoublingCommunicator2D:
         starts = [0] * mpi_construct.grid_dim
         self.send_from_doubled_to_actual_domain_first_half_type = (
             self.mpi_construct.dtype_generator.Create_subarray(
-                sizes=self.field_doubled_sub_size,
-                subsizes=self.field_sub_size,
+                sizes=self.field_doubled_grid_size,
+                subsizes=self.field_grid_size,
                 starts=starts,
             )
         )
         self.send_from_doubled_to_actual_domain_first_half_type.Commit()
         # (b) Second half (start offset assumes slab decomp)
         starts = [0, 0]
-        starts[self.distributed_dim] = self.field_sub_size[self.distributed_dim]
+        starts[self.distributed_dim] = self.field_grid_size[self.distributed_dim]
         self.send_from_doubled_to_actual_domain_second_half_type = (
             self.mpi_construct.dtype_generator.Create_subarray(
-                sizes=self.field_doubled_sub_size,
-                subsizes=self.field_sub_size,
+                sizes=self.field_doubled_grid_size,
+                subsizes=self.field_grid_size,
                 starts=starts,
             )
         )
@@ -257,8 +257,8 @@ class MPIDomainDoublingCommunicator2D:
         starts = [self.ghost_size] * mpi_construct.grid_dim
         self.recv_from_doubled_to_actual_domain_type = (
             self.mpi_construct.dtype_generator.Create_subarray(
-                sizes=self.field_sub_size + 2 * self.ghost_size,
-                subsizes=self.field_sub_size,
+                sizes=self.field_grid_size + 2 * self.ghost_size,
+                subsizes=self.field_grid_size,
                 starts=starts,
             )
         )

--- a/sopht_mpi/numeric/eulerian_grid_ops/poisson_solver_2d/__init__.py
+++ b/sopht_mpi/numeric/eulerian_grid_ops/poisson_solver_2d/__init__.py
@@ -1,1 +1,2 @@
 from .fft_mpi_2d import FFTMPI2D
+from .UnboundedPoissonSolverMPI2D import UnboundedPoissonSolverMPI2D

--- a/sopht_mpi/numeric/eulerian_grid_ops/poisson_solver_2d/fft_mpi_2d.py
+++ b/sopht_mpi/numeric/eulerian_grid_ops/poisson_solver_2d/fft_mpi_2d.py
@@ -18,6 +18,7 @@ class FFTMPI2D:
         self.field_buffer = DistArray(
             global_shape=(grid_size_y, grid_size_x),
             subcomm=mpi_construct.rank_distribution,
+            dtype=self.real_dtype,
         )
         # Use generated distributed array to create parallel fft plan
         self.fft = PFFT(

--- a/tests/test_numeric/test_eulerian_grid_ops/test_poisson_solver_2d/test_unbounded_poisson_solver_mpi_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_poisson_solver_2d/test_unbounded_poisson_solver_mpi_2d.py
@@ -1,0 +1,97 @@
+import numpy as np
+import pytest
+from sopht.utils.precision import get_real_t, get_test_tol
+from sopht.numeric.eulerian_grid_ops.poisson_solver_2d import (
+    UnboundedPoissonSolverPYFFTW2D,
+)
+from sopht_mpi.utils import (
+    MPIConstruct2D,
+    MPIFieldCommunicator2D,
+)
+from sopht_mpi.numeric.eulerian_grid_ops.poisson_solver_2d import (
+    UnboundedPoissonSolverMPI2D,
+)
+import os
+
+os.environ["KMP_DUPLICATE_LIB_OK"] = "True"
+
+
+@pytest.mark.mpi(group="MPI_unbounded_poisson_solve_2d", min_size=2)
+@pytest.mark.parametrize("ghost_size", [1, 2, 3])
+@pytest.mark.parametrize("precision", ["single", "double"])
+@pytest.mark.parametrize("rank_distribution", [(1, 0), (0, 1)])
+@pytest.mark.parametrize("aspect_ratio", [(1, 1), (1, 2), (2, 1)])
+def test_mpi_unbounded_poisson_solve_2d(
+    ghost_size, precision, rank_distribution, aspect_ratio
+):
+    n_values = 32
+    real_t = get_real_t(precision)
+    # Generate the MPI topology minimal object
+    mpi_construct = MPIConstruct2D(
+        grid_size_y=n_values * aspect_ratio[0],
+        grid_size_x=n_values * aspect_ratio[1],
+        real_t=real_t,
+        rank_distribution=rank_distribution,
+    )
+
+    # Create unbounded poisson solver
+    unbounded_poisson_solver = UnboundedPoissonSolverMPI2D(
+        grid_size_y=n_values * aspect_ratio[0],
+        grid_size_x=n_values * aspect_ratio[1],
+        real_t=real_t,
+        mpi_construct=mpi_construct,
+        ghost_size=ghost_size,
+    )
+
+    # Initialize communicator for scatter and gather
+    mpi_field_comm = MPIFieldCommunicator2D(
+        ghost_size=ghost_size, mpi_construct=mpi_construct
+    )
+    gather_local_field = mpi_field_comm.gather_local_field
+    scatter_global_field = mpi_field_comm.scatter_global_field
+
+    # Allocate local field
+    local_rhs_field = np.zeros(
+        (
+            mpi_construct.local_grid_size[0] + 2 * ghost_size,
+            mpi_construct.local_grid_size[1] + 2 * ghost_size,
+        )
+    ).astype(real_t)
+    local_solution_field = np.zeros_like(local_rhs_field)
+
+    # Initialize and broadcast solution for comparison later
+    if mpi_construct.rank == 0:
+        ref_rhs_field = np.random.rand(
+            n_values * aspect_ratio[0], n_values * aspect_ratio[1]
+        ).astype(real_t)
+    else:
+        ref_rhs_field = None
+
+    # scatter global field
+    scatter_global_field(local_rhs_field, ref_rhs_field, mpi_construct)
+
+    # compute the unbounded poisson solve
+    unbounded_poisson_solver.solve(
+        solution_field=local_solution_field, rhs_field=local_rhs_field
+    )
+
+    # gather back the solution field globally
+    global_solution_field = np.zeros_like(ref_rhs_field)
+    gather_local_field(global_solution_field, local_solution_field, mpi_construct)
+
+    # assert correct
+    if mpi_construct.rank == 0:
+        ref_unbounded_poisson_solver = UnboundedPoissonSolverPYFFTW2D(
+            grid_size_y=n_values * aspect_ratio[0],
+            grid_size_x=n_values * aspect_ratio[1],
+            real_t=real_t,
+        )
+        ref_solution_field = np.zeros_like(ref_rhs_field)
+        ref_unbounded_poisson_solver.solve(
+            solution_field=ref_solution_field, rhs_field=ref_rhs_field
+        )
+        np.testing.assert_allclose(
+            ref_solution_field,
+            global_solution_field,
+            atol=get_test_tol(precision),
+        )

--- a/tests/test_numeric/test_eulerian_grid_ops/test_poisson_solver_2d/test_unbounded_poisson_solver_mpi_2d.py
+++ b/tests/test_numeric/test_eulerian_grid_ops/test_poisson_solver_2d/test_unbounded_poisson_solver_mpi_2d.py
@@ -11,9 +11,6 @@ from sopht_mpi.utils import (
 from sopht_mpi.numeric.eulerian_grid_ops.poisson_solver_2d import (
     UnboundedPoissonSolverMPI2D,
 )
-import os
-
-os.environ["KMP_DUPLICATE_LIB_OK"] = "True"
 
 
 @pytest.mark.mpi(group="MPI_unbounded_poisson_solve_2d", min_size=2)


### PR DESCRIPTION
Fixes #36 

So I coded an exclusive communicator to deal with communications between actual and doubled domains needed for the unbounded poisson solve. I tried to be explicit in the code as best as I could with comments and variable namings, and if any of those are unclear you can bring them up in the review or if anything is major, short discussion in person might be more efficient.

We should probably think about where to put the communicator code. As of now, I put them in the same file as `UnboundedPoissonSolverMPI2D.py`, since only that solver uses that communicator, specially written for it. I don't think it should go in `mpi_utils_2d.py`, since it's not generically used throughout sopht-mpi. If you feel strongly that we should put the communicator in a different file, may I suggest a `poisson_solver_utils_mpi_2d.py` or something in the same directory, so these poisson solver-related stuff are contained in the same poisson directory. Please let me know what you think.

Please find attached for a rough description of the communication pattern used here.

![IMG_1170](https://user-images.githubusercontent.com/12764958/193370125-1a2cb4ce-4bac-4b71-8aba-5bd43bd5d0d0.jpg)
