### PR TITLE
MPI-supported plotting tool with matplotlib-style

### DIFF
--- a/sopht_mpi/utils/__init__.py
+++ b/sopht_mpi/utils/__init__.py
@@ -2,6 +2,7 @@ from .mpi_utils_2d import (
     MPIConstruct2D,
     MPIGhostCommunicator2D,
     MPIFieldCommunicator2D,
+    MPIPlotter2D,
 )
 from .mpi_utils_3d import (
     MPIConstruct3D,
@@ -9,3 +10,4 @@ from .mpi_utils_3d import (
     MPIFieldCommunicator3D,
 )
 from .mpi_utils import check_valid_ghost_size_and_kernel_support
+from .lab_cmap import *

--- a/sopht_mpi/utils/lab_cmap.py
+++ b/sopht_mpi/utils/lab_cmap.py
@@ -1,0 +1,14 @@
+__all__ = ["lab_cmap"]
+import numpy as np
+from matplotlib.colors import ListedColormap
+from matplotlib import cm
+
+# Custom map resembling Orange-Blue scheme
+res = 256
+top = cm.get_cmap("Oranges", 256)
+bottom = cm.get_cmap("Blues", 256)
+
+newcolors = np.vstack(
+    (top(np.linspace(0.75, 0, 256)), bottom(np.linspace(0, 0.75, 256)))
+)
+lab_cmap = ListedColormap(newcolors, name="OrangeBlue").reversed()


### PR DESCRIPTION
Fixes #49 

The use case for this will be shown when I push the PR for 2D unbounded flow simulator. The following demonstrates roughly the pseudo-code to use this.

```python3
# Initialize MPI-related stuff as usual
mpi_construct = ...
ghost_size = ...

# Assume you have these global arrays
global_field = ...
global_x_grid = ...
global_y_grid = ...

# And now you work on local arrays
scatter(local_field, global_field, ...)
scatter(local_x_grid, global_x_grid, ...)
scatter(local_y_grid, global_y_grid, ...)

# Initialize field plotter
mpi_plotter = MPIPlotter2D(mpi_construct, ghost_size)

# mpi_plotter will take care of gathering field to rank 0 and save
mpi_plotter.contourf(local_x_grid, local_y_grid, local_field, title="Some field", extend="both")

# save fig like you wouldin matplotlib
mpi_plotter.savefig(file_name="some_field.png")

# clear fig if needed (for next iteration etc)
mpi_plotter.clearfig()
```