### PR TITLE
MPI-supported Eulerian-Lagrangian grid communicator

### DIFF
--- a/sopht_mpi/numeric/immersed_boundary_ops/EulerianLagrangianGridCommunicatorMPI2D.py
+++ b/sopht_mpi/numeric/immersed_boundary_ops/EulerianLagrangianGridCommunicatorMPI2D.py
@@ -1,0 +1,641 @@
+"""MPI-supported Eulerian-Lagrangian grid communicator in 2D."""
+from numba import njit
+import numpy as np
+
+
+class EulerianLagrangianGridCommunicatorMPI2D:
+    """Class for MPI-supported communication between Eulerian and Lagrangian grids in 2D
+
+    Sets up a MPI-supported communicator between Eulerian and Lagrangian grids in the
+    domain, which consists of:
+    1. Find grid intersections (nearest indices)
+    2. Interpolate fields back and forth
+    3. Compute interpolation weights for interpolation
+    """
+
+    def __init__(
+        self,
+        dx,
+        eul_grid_coord_shift,
+        interp_kernel_width,
+        real_t,
+        mpi_construct,
+        ghost_size,
+        n_components=1,
+        interp_kernel_type="cosine",
+    ):
+        """Class initialiser."""
+        if n_components != 1 and n_components != 2:
+            raise ValueError("invalid number of components for eul-lag interpolation!")
+
+        # MPI-related variables
+        self.mpi_construct = mpi_construct
+        self.mpi_ghost_sum_comm = MPIGhostSumCommunicator2D(
+            ghost_size=ghost_size, mpi_construct=self.mpi_construct
+        )
+        # Compute mpi rank local eul grid coord shift (accounting also for ghost cell)
+        self.mpi_substart_idx = np.flip(
+            mpi_construct.grid.coords * mpi_construct.local_grid_size
+        )
+        self.mpi_local_eul_grid_coord_shift = (
+            eul_grid_coord_shift + dx * (self.mpi_substart_idx - ghost_size)
+        ).astype(real_t)
+
+        # Kernel generation
+        # Local eulerian grid support (nearest indices)
+        self.local_eulerian_grid_support_of_lagrangian_grid_kernel = (
+            generate_local_eulerian_grid_support_of_lagrangian_grid_kernel_2d(
+                dx=dx,
+                eul_grid_coord_shift=self.mpi_local_eul_grid_coord_shift,
+                interp_kernel_width=interp_kernel_width,
+            )
+        )
+
+        # Eulerian to lagrangian grid interpolation
+        self.eulerian_to_lagrangian_grid_interpolation_kernel = (
+            generate_eulerian_to_lagrangian_grid_interpolation_kernel_2d(
+                dx=dx,
+                interp_kernel_width=interp_kernel_width,
+                n_components=n_components,
+            )
+        )
+
+        # Lagrangian to eulerian grid interpolation
+        self.lagrangian_to_eulerian_grid_interpolation_kernel_without_ghost_sum = (
+            generate_lagrangian_to_eulerian_grid_interpolation_kernel_2d(
+                interp_kernel_width=interp_kernel_width,
+                n_components=n_components,
+            )
+        )
+
+        # Eulerian grid ghost sum kernel
+        self.eulerian_grid_ghost_sum = generate_eulerian_grid_ghost_sum(
+            n_components, self.mpi_ghost_sum_comm
+        )
+
+        if interp_kernel_type == "peskin":
+            self.interpolation_weights_kernel = (
+                generate_peskin_interpolation_weights_kernel_2d(
+                    dx=dx, interp_kernel_width=interp_kernel_width, real_t=real_t
+                )
+            )
+        elif interp_kernel_type == "cosine":
+            self.interpolation_weights_kernel = (
+                generate_cosine_interpolation_weights_kernel_2d(
+                    dx=dx, interp_kernel_width=interp_kernel_width, real_t=real_t
+                )
+            )
+        else:
+            raise ValueError(
+                "Invalid interpolation kernel type. Currently supported types are"
+                "'cosine' and 'peskin'."
+            )
+
+    def lagrangian_to_eulerian_grid_interpolation_kernel(
+        self,
+        eul_grid_field,
+        lag_grid_field,
+        interp_weights,
+        nearest_eul_grid_index_to_lag_grid,
+    ):
+        self.lagrangian_to_eulerian_grid_interpolation_kernel_without_ghost_sum(
+            eul_grid_field,
+            lag_grid_field,
+            interp_weights,
+            nearest_eul_grid_index_to_lag_grid,
+        )
+        # Add ghost cell contribution to neighbors and zero out ghost cells
+        self.eulerian_grid_ghost_sum(local_field=eul_grid_field)
+
+
+def generate_local_eulerian_grid_support_of_lagrangian_grid_kernel_2d(
+    dx, eul_grid_coord_shift, interp_kernel_width
+):
+    """
+    Generate kernel that computes local Eulerian support of Lagrangian grid.
+
+    Inputs:
+    interp_kernel_width: width of interpolation kernel
+    eul_grid_coord_shift: shift of the coordinates of the local Eulerian grid start
+    (i.e. starting point of current local Eulerian grid)
+    dx: Eulerian grid spacing
+
+    """
+    # grid/problem dimensions
+    grid_dim = 2
+    x = np.arange(-interp_kernel_width + 1, interp_kernel_width + 1)
+    x_grid, y_grid = np.meshgrid(x, x)
+    local_eul_grid_support_idx = np.stack((x_grid, y_grid))
+
+    # Note: Here we don't set cache=True for the numba kernel since it uses the varibale
+    # `eul_grid_coord_shift`, which varies between ranks, and each rank seems to
+    # contaminate the cached kernel, where each rank overwrites the numba cache and it
+    # causes a race condition. Consequently, since constants are not rebinded, we end up
+    # using wrong value at some of the ranks. This is mentioned in the limitations
+    # section found in https://numba.pydata.org/numba-doc/latest/developer/caching.html
+    # Another workaround for this is to make this as a variable in the kernel below, and
+    # caching wont be a problem anymore since the variable is passed in when kernel is
+    # called (i.e. not a constant, at least in the numba kernel)
+    @njit(fastmath=True)
+    def local_eulerian_grid_support_of_lagrangian_grid_kernel_2d(
+        local_eul_grid_support_of_lag_grid,
+        nearest_eul_grid_index_to_lag_grid,
+        lag_positions,
+    ):
+        """Compute local Eulerian support of Lagrangian grid.
+
+        Return nearest_eul_grid_index_to_lag_grid: size (grid_dim, num_lag_nodes)
+        local_eul_grid_support_of_lag_grid: local Eulerian grid support of the Lagrangian grid
+        (grid_dim, 2 * interp_kernel_width, 2 * interp_kernel_width, num_lag_nodes)
+        from input params:
+        lag_positions: (grid_dim, num_lag_nodes)
+
+        """
+        # dtype of nearest_grid_index takes care of type casting to int
+        nearest_eul_grid_index_to_lag_grid[...] = (
+            lag_positions - eul_grid_coord_shift.reshape(grid_dim, -1)
+        ) // dx
+
+        # reshape done to broadcast
+        local_eul_grid_support_of_lag_grid[...] = (
+            (
+                nearest_eul_grid_index_to_lag_grid.reshape(grid_dim, 1, 1, -1)
+                + local_eul_grid_support_idx.reshape(
+                    grid_dim, 2 * interp_kernel_width, 2 * interp_kernel_width, 1
+                )
+            )
+            * dx
+            + eul_grid_coord_shift.reshape(grid_dim, 1, 1, 1)
+            - lag_positions.reshape(grid_dim, 1, 1, -1)
+        )
+
+    return local_eulerian_grid_support_of_lagrangian_grid_kernel_2d
+
+
+def generate_eulerian_to_lagrangian_grid_interpolation_kernel_2d(
+    dx, interp_kernel_width, n_components
+):
+    """Generate kernel that interpolates a field from an Eulerian grid to a Lagrangian grid.
+
+    Inputs:
+    interp_kernel_width: width of interpolation kernel
+    dx: Eulerian grid spacing
+    n_components : number of components in Lagrangian field
+
+    """
+    assert (
+        n_components == 1 or n_components == 2
+    ), "invalid number of components for interpolation!"
+    # grid/problem dimensions
+    grid_dim = 2
+
+    @njit(cache=True, fastmath=True)
+    def eulerian_to_lagrangian_grid_interpolation_kernel_2d(
+        lag_grid_field,
+        eul_grid_field,
+        interp_weights,
+        nearest_eul_grid_index_to_lag_grid,
+    ):
+        """Interpolate an Eulerian field onto a Lagrangian field.
+
+        Inputs:
+        the nearest_eul_grid_index_to_lag_grid(grid_dim, num_lag_nodes) and
+        interpolation weights interp_weights of
+        shape (2 * interp_kernel_width, 2 * interp_kernel_width, num_lag_nodes)
+
+        """
+        num_lag_nodes = lag_grid_field.shape[-1]
+        for i in range(0, num_lag_nodes):
+            lag_grid_field[i] = np.sum(
+                eul_grid_field[
+                    nearest_eul_grid_index_to_lag_grid[1, i]
+                    - interp_kernel_width
+                    + 1 : nearest_eul_grid_index_to_lag_grid[1, i]
+                    + interp_kernel_width
+                    + 1,
+                    nearest_eul_grid_index_to_lag_grid[0, i]
+                    - interp_kernel_width
+                    + 1 : nearest_eul_grid_index_to_lag_grid[0, i]
+                    + interp_kernel_width
+                    + 1,
+                ]
+                * interp_weights[..., i]
+            ) * (dx**grid_dim)
+
+    @njit(cache=True, fastmath=True)
+    def vector_field_eulerian_to_lagrangian_grid_interpolation_kernel_2d(
+        lag_grid_field,
+        eul_grid_field,
+        interp_weights,
+        nearest_eul_grid_index_to_lag_grid,
+    ):
+        """Interpolate an Eulerian vector field onto a Lagrangian vector field.
+
+        Inputs:
+        the nearest_eul_grid_index_to_lag_grid(grid_dim, num_lag_nodes) and
+        interpolation weights interp_weights of
+        shape (2 * interp_kernel_width, 2 * interp_kernel_width, num_lag_nodes)
+
+        """
+        num_lag_nodes = lag_grid_field.shape[-1]
+        for i in range(0, num_lag_nodes):
+            # numba doesnt allow multiple axes for np.sum :/,
+            # hence needs to be done serially
+            lag_grid_field[0, i] = np.sum(
+                eul_grid_field[
+                    0,
+                    nearest_eul_grid_index_to_lag_grid[1, i]
+                    - interp_kernel_width
+                    + 1 : nearest_eul_grid_index_to_lag_grid[1, i]
+                    + interp_kernel_width
+                    + 1,
+                    nearest_eul_grid_index_to_lag_grid[0, i]
+                    - interp_kernel_width
+                    + 1 : nearest_eul_grid_index_to_lag_grid[0, i]
+                    + interp_kernel_width
+                    + 1,
+                ]
+                * interp_weights[..., i]
+            ) * (dx**grid_dim)
+            lag_grid_field[1, i] = np.sum(
+                eul_grid_field[
+                    1,
+                    nearest_eul_grid_index_to_lag_grid[1, i]
+                    - interp_kernel_width
+                    + 1 : nearest_eul_grid_index_to_lag_grid[1, i]
+                    + interp_kernel_width
+                    + 1,
+                    nearest_eul_grid_index_to_lag_grid[0, i]
+                    - interp_kernel_width
+                    + 1 : nearest_eul_grid_index_to_lag_grid[0, i]
+                    + interp_kernel_width
+                    + 1,
+                ]
+                * interp_weights[..., i]
+            ) * (dx**grid_dim)
+
+    if n_components == 1:
+        return eulerian_to_lagrangian_grid_interpolation_kernel_2d
+    else:
+        return vector_field_eulerian_to_lagrangian_grid_interpolation_kernel_2d
+
+
+def generate_lagrangian_to_eulerian_grid_interpolation_kernel_2d(
+    interp_kernel_width, n_components=1
+):
+    """Generate kernel that interpolates a field from a Lagrangian grid to an Eulerian grid.
+
+    Inputs:
+    interp_kernel_width: width of interpolation kernel
+    n_components : number of components in Lagrangian field
+
+    """
+
+    @njit(cache=True, fastmath=True)
+    def lagrangian_to_eulerian_grid_interpolation_kernel_2d(
+        eul_grid_field,
+        lag_grid_field,
+        interp_weights,
+        nearest_eul_grid_index_to_lag_grid,
+    ):
+        """Interpolate a Lagrangian field onto an Eulerian field.
+
+        Inputs:
+        the nearest_eul_grid_index_to_lag_grid(grid_dim, num_lag_nodes) and
+        interpolation weights interp_weights of
+        shape (2 * interp_kernel_width, 2 * interp_kernel_width, num_lag_nodes)
+
+        """
+        num_lag_nodes = lag_grid_field.shape[-1]
+        for i in range(0, num_lag_nodes):
+            eul_grid_field[
+                nearest_eul_grid_index_to_lag_grid[1, i]
+                - interp_kernel_width
+                + 1 : nearest_eul_grid_index_to_lag_grid[1, i]
+                + interp_kernel_width
+                + 1,
+                nearest_eul_grid_index_to_lag_grid[0, i]
+                - interp_kernel_width
+                + 1 : nearest_eul_grid_index_to_lag_grid[0, i]
+                + interp_kernel_width
+                + 1,
+            ] += (
+                lag_grid_field[..., i] * interp_weights[..., i]
+            )
+
+    @njit(cache=True, fastmath=True)
+    def vector_field_lagrangian_to_eulerian_grid_interpolation_kernel_2d(
+        eul_grid_field,
+        lag_grid_field,
+        interp_weights,
+        nearest_eul_grid_index_to_lag_grid,
+    ):
+        """Interpolate a Lagrangian vector field onto an Eulerian field.
+
+        Inputs:
+        the nearest_eul_grid_index_to_lag_grid(grid_dim, num_lag_nodes) and
+        interpolation weights interp_weights of
+        shape (2 * interp_kernel_width, 2 * interp_kernel_width, num_lag_nodes)
+
+        """
+        # TODO We need to add boundary exception handling! where the Lagrangian
+        #  node goes in `interp_kernel_width` boundary zone of the Eulerian grid
+        num_lag_nodes = lag_grid_field.shape[-1]
+        for i in range(0, num_lag_nodes):
+            eul_grid_field[
+                ...,
+                nearest_eul_grid_index_to_lag_grid[1, i]
+                - interp_kernel_width
+                + 1 : nearest_eul_grid_index_to_lag_grid[1, i]
+                + interp_kernel_width
+                + 1,
+                nearest_eul_grid_index_to_lag_grid[0, i]
+                - interp_kernel_width
+                + 1 : nearest_eul_grid_index_to_lag_grid[0, i]
+                + interp_kernel_width
+                + 1,
+            ] += (
+                np.ascontiguousarray(lag_grid_field[..., i]).reshape(-1, 1, 1)
+                * interp_weights[..., i]
+            )
+
+    if n_components == 1:
+        return lagrangian_to_eulerian_grid_interpolation_kernel_2d
+    else:
+        return vector_field_lagrangian_to_eulerian_grid_interpolation_kernel_2d
+
+
+def generate_eulerian_grid_ghost_sum(n_components, mpi_ghost_sum_comm):
+    if n_components == 1:
+        return mpi_ghost_sum_comm.ghost_sum
+    else:
+
+        def vector_field_ghost_sum(local_field):
+            mpi_ghost_sum_comm.ghost_sum(local_field[0])
+            mpi_ghost_sum_comm.ghost_sum(local_field[1])
+
+        return vector_field_ghost_sum
+
+
+def generate_cosine_interpolation_weights_kernel_2d(dx, interp_kernel_width, real_t):
+    """Generate the kernel for computing interpolation weights using 2D cosine delta function.
+
+    Inputs:
+    interp_kernel_width: width of interpolation kernel
+    dx : Eulerian grid spacing
+
+    """
+    # grid/problem dimensions
+    grid_dim = 2
+    assert (
+        interp_kernel_width == 2
+    ), "Interpolation kernel inconsistent with interpolation kernel width!"
+
+    @njit(cache=True, fastmath=True)
+    def cosine_interpolation_weights_kernel_2d(
+        interp_weights, local_eul_grid_support_of_lag_grid
+    ):
+        """Compute the interpolation weights using 2D cosine delta function.
+
+        Result stored in interp_weights of shape
+        (2 * interp_kernel_width, 2 * interp_kernel_width, ...) with
+        input as eul_grid_support_of_lag_grid of shape
+        (grid_dim, 2 * interp_kernel_width, 2 * interp_kernel_width, ...)
+        Applicable for interp_kernel_width = 2
+        """
+        local_eul_grid_support_of_lag_grid /= dx
+        interp_weights[...] = (
+            real_t((0.25 / dx) ** grid_dim)
+            * (
+                real_t(1.0)
+                + np.cos(real_t(0.5 * np.pi) * local_eul_grid_support_of_lag_grid[0])
+            )
+            * (
+                real_t(1.0)
+                + np.cos(real_t(0.5 * np.pi) * local_eul_grid_support_of_lag_grid[1])
+            )
+        )
+
+    return cosine_interpolation_weights_kernel_2d
+
+
+def generate_peskin_interpolation_weights_kernel_2d(dx, interp_kernel_width, real_t):
+    """Generate the kernel for computing interpolation weights proposed by Peskin, 2002, 6.27.
+
+    Inputs:
+    interp_kernel_width: width of interpolation kernel
+    dx : Eulerian grid spacing
+
+    """
+    # grid/problem dimensions
+    grid_dim = 2
+    assert (
+        interp_kernel_width == 2
+    ), "Interpolation kernel inconsistent with interpolation kernel width!"
+
+    @njit(cache=True, fastmath=True)
+    def peskin_interpolation_weights_kernel_2d(
+        interp_weights, local_eul_grid_support_of_lag_grid
+    ):
+        """Compute the interpolation weights using 2D delta function by Peskin, 2002.
+
+        Result stored in interp_weights of shape
+        (2 * interp_kernel_width, 2 * interp_kernel_width, ...) with
+        input as eul_grid_support_of_lag_grid of shape
+        (grid_dim, 2 * interp_kernel_width, 2 * interp_kernel_width, ...)
+        Applicable for interp_kernel_width = 2
+        """
+        local_eul_grid_support_of_lag_grid[...] = (
+            np.fabs(local_eul_grid_support_of_lag_grid) / dx
+        )
+        interp_weights[...] = (
+            (0.125 / dx) ** grid_dim
+            * (
+                (local_eul_grid_support_of_lag_grid[0] < 1.0)
+                * (
+                    3.0
+                    - 2 * local_eul_grid_support_of_lag_grid[0]
+                    + np.sqrt(
+                        np.fabs(
+                            1
+                            + 4 * local_eul_grid_support_of_lag_grid[0]
+                            - 4 * local_eul_grid_support_of_lag_grid[0] ** 2
+                        )
+                    )
+                )
+                + (local_eul_grid_support_of_lag_grid[0] >= 1.0)
+                * (local_eul_grid_support_of_lag_grid[0] < 2.0)
+                * (
+                    5.0
+                    - 2 * local_eul_grid_support_of_lag_grid[0]
+                    - np.sqrt(
+                        np.fabs(
+                            -7
+                            + 12 * local_eul_grid_support_of_lag_grid[0]
+                            - 4 * local_eul_grid_support_of_lag_grid[0] ** 2
+                        )
+                    )
+                )
+            )
+            * (
+                (local_eul_grid_support_of_lag_grid[1] < 1.0)
+                * (
+                    3.0
+                    - 2 * local_eul_grid_support_of_lag_grid[1]
+                    + np.sqrt(
+                        np.fabs(
+                            1
+                            + 4 * local_eul_grid_support_of_lag_grid[1]
+                            - 4 * local_eul_grid_support_of_lag_grid[1] ** 2
+                        )
+                    )
+                )
+                + (local_eul_grid_support_of_lag_grid[1] >= 1.0)
+                * (local_eul_grid_support_of_lag_grid[1] < 2.0)
+                * (
+                    5.0
+                    - 2 * local_eul_grid_support_of_lag_grid[1]
+                    - np.sqrt(
+                        np.fabs(
+                            -7
+                            + 12 * local_eul_grid_support_of_lag_grid[1]
+                            - 4 * local_eul_grid_support_of_lag_grid[1] ** 2
+                        )
+                    )
+                )
+            )
+        ).astype(real_t)
+
+    return peskin_interpolation_weights_kernel_2d
+
+
+class MPIGhostSumCommunicator2D:
+    """
+    Class exclusive for ghost field communication between ranks in eulerian lagrangian
+    grid context.
+    This communicator enables the influence of lagrangian nodes on eulerian nodes that
+    resides in the ghost cell to be transferred and accumulated over to neighbour ranks.
+    """
+
+    def __init__(self, ghost_size, mpi_construct):
+        self.mpi_construct = mpi_construct
+        # Use ghost_size to define offset indices for inner cell
+        if ghost_size < 0 and not isinstance(ghost_size, int):
+            raise ValueError(
+                f"Ghost size {ghost_size} needs to be an integer >= 0"
+                "for field communication."
+            )
+        self.ghost_size = ghost_size
+        # define field_size variable for local field size (which includes ghost)
+        self.field_size = mpi_construct.local_grid_size + 2 * self.ghost_size
+
+        # Set datatypes for ghost communication
+        # For row we use contiguous type
+        self.row_type = mpi_construct.dtype_generator.Create_contiguous(
+            count=self.ghost_size * self.field_size[1]
+        )
+        self.row_type.Commit()
+        # For column we use strided vector
+        self.column_type = mpi_construct.dtype_generator.Create_vector(
+            count=self.field_size[0],
+            blocklength=self.ghost_size,
+            stride=self.field_size[1],
+        )
+        self.column_type.Commit()
+
+        # Create buffers for receiving
+        self.row_buffer = np.zeros(
+            (self.ghost_size, self.field_size[1]), dtype=mpi_construct.real_t
+        )
+        self.col_buffer = np.zeros(
+            (self.field_size[0], self.ghost_size), dtype=mpi_construct.real_t
+        )
+
+    def ghost_sum(self, local_field):
+        """
+        Add ghost data in each rank to corresponding neighboring rank, followed by
+        clearing out the ghost cell values.
+
+        Note: We use blocking calls here to ensure proper accumulation of ghost cells to
+        their corresponding ranks.
+        """
+        # Lines below to make code more literal
+        y_axis = 0
+        x_axis = 1
+
+        # Along Y: send to next block, receive from previous block
+        self.mpi_construct.grid.Send(
+            (
+                local_field[-self.ghost_size : local_field.shape[0], :],
+                1,
+                self.row_type,
+            ),
+            dest=self.mpi_construct.next_grid_along[y_axis],
+        )
+        self.mpi_construct.grid.Recv(
+            self.row_buffer,
+            source=self.mpi_construct.previous_grid_along[y_axis],
+        )
+        # add to field
+        local_field[self.ghost_size : 2 * self.ghost_size, :] += self.row_buffer
+        # clear buffer values
+        self.row_buffer *= 0
+
+        # # Along X: send to next block, receive from previous block
+        self.mpi_construct.grid.Send(
+            (
+                local_field.ravel()[local_field.shape[1] - self.ghost_size :],
+                1,
+                self.column_type,
+            ),
+            dest=self.mpi_construct.next_grid_along[x_axis],
+        )
+        self.mpi_construct.grid.Recv(
+            self.col_buffer,
+            source=self.mpi_construct.previous_grid_along[x_axis],
+        )
+        # add to field
+        local_field[:, self.ghost_size : 2 * self.ghost_size] += self.col_buffer
+        # clear buffer values
+        self.col_buffer *= 0
+
+        # Along Y: send to previous block, receive from next block
+        self.mpi_construct.grid.Send(
+            (
+                local_field[0 : self.ghost_size, :],
+                1,
+                self.row_type,
+            ),
+            dest=self.mpi_construct.previous_grid_along[y_axis],
+        )
+        self.mpi_construct.grid.Recv(
+            self.row_buffer,
+            source=self.mpi_construct.next_grid_along[y_axis],
+        )
+        # add to field
+        local_field[-2 * self.ghost_size : -self.ghost_size, :] += self.row_buffer
+
+        # Along X: send to previous block, receive from next block
+        self.mpi_construct.grid.Send(
+            (
+                local_field.ravel()[0:],
+                1,
+                self.column_type,
+            ),
+            dest=self.mpi_construct.previous_grid_along[x_axis],
+        )
+        self.mpi_construct.grid.Recv(
+            self.col_buffer,
+            source=self.mpi_construct.next_grid_along[x_axis],
+        )
+        # add to field
+        local_field[:, -2 * self.ghost_size : -self.ghost_size] += self.col_buffer
+
+        # zero out ghost cells
+        self.clear_ghost_cells(local_field)
+
+    def clear_ghost_cells(self, field):
+        field[: self.ghost_size, :] *= 0
+        field[-self.ghost_size :, :] *= 0
+        field[:, : self.ghost_size] *= 0
+        field[:, -self.ghost_size :] *= 0

--- a/sopht_mpi/numeric/immersed_boundary_ops/EulerianLagrangianGridCommunicatorMPI2D.py
+++ b/sopht_mpi/numeric/immersed_boundary_ops/EulerianLagrangianGridCommunicatorMPI2D.py
@@ -614,6 +614,7 @@ class MPIGhostSumCommunicator2D:
         )
         # add to field
         local_field[-2 * self.ghost_size : -self.ghost_size, :] += self.row_buffer
+        self.row_buffer *= 0
 
         # Along X: send to previous block, receive from next block
         self.mpi_construct.grid.Send(
@@ -630,6 +631,7 @@ class MPIGhostSumCommunicator2D:
         )
         # add to field
         local_field[:, -2 * self.ghost_size : -self.ghost_size] += self.col_buffer
+        self.col_buffer *= 0
 
         # zero out ghost cells
         self.clear_ghost_cells(local_field)

--- a/sopht_mpi/numeric/immersed_boundary_ops/__init__.py
+++ b/sopht_mpi/numeric/immersed_boundary_ops/__init__.py
@@ -1,0 +1,4 @@
+"""Immersed boundary operations."""
+from .EulerianLagrangianGridCommunicatorMPI2D import (
+    EulerianLagrangianGridCommunicatorMPI2D,
+)

--- a/tests/test_numeric/test_immersed_boundary_ops/test_eulerian_lagrangian_grid_communicator_mpi_2d.py
+++ b/tests/test_numeric/test_immersed_boundary_ops/test_eulerian_lagrangian_grid_communicator_mpi_2d.py
@@ -11,6 +11,152 @@ from sopht_mpi.utils import (
 from sopht.utils.precision import get_real_t, get_test_tol
 
 
+class MockEulLagGridCommSolution:
+    """
+    Mock solution test class based on sopht-backend for 2D Eulerian-Lagrangian grid
+    communicator
+    """
+
+    def __init__(
+        self,
+        n_values,
+        aspect_ratio,
+        precision,
+        interp_kernel_type="cosine",
+        n_components=1,
+    ):
+        self.real_t = get_real_t(precision)
+        self.grid_dim = 2
+        self.eul_grid_size_y = n_values * aspect_ratio[0]
+        self.eul_grid_size_x = n_values * aspect_ratio[1]
+        self.eul_grid_size = self.eul_grid_size_x
+        self.eul_domain_size = self.real_t(1.0)
+        self.eul_grid_dx = self.real_t(self.eul_domain_size / self.eul_grid_size)
+        self.eul_grid_coord_shift = self.real_t(0.5 * self.eul_grid_dx)
+        self.interp_kernel_width = 2
+        self.num_lag_nodes = 3
+        self.interp_kernel_type = interp_kernel_type
+        self.n_components = n_components
+
+        self.generate_reference_solution()
+
+    def generate_reference_solution(self):
+        """Generate reference solution from sopht-backend"""
+        self.eul_lag_communicator = EulerianLagrangianGridCommunicator2D(
+            dx=self.eul_grid_dx,
+            eul_grid_coord_shift=self.eul_grid_coord_shift,
+            num_lag_nodes=self.num_lag_nodes,
+            interp_kernel_width=self.interp_kernel_width,
+            n_components=self.n_components,
+            real_t=self.real_t,
+        )
+        # init lag. grid around center of the domain
+        # this allows testing for the case where rank on first and last quarter (when there
+        # are 4 processes) does not contain any lagrangian nodes AND when the point lies at
+        # the boundary of MPI domain decomposition
+        self.nearest_eul_grid_index_to_lag_grid = np.empty(
+            (self.grid_dim, self.num_lag_nodes)
+        ).astype(int)
+        self.nearest_eul_grid_index_to_lag_grid[0] = np.arange(
+            self.eul_grid_size_x // 2 - 1,
+            self.eul_grid_size_x // 2 - 1 + self.num_lag_nodes,
+        ).astype(int)
+        self.nearest_eul_grid_index_to_lag_grid[1] = np.arange(
+            self.eul_grid_size_y // 2 - 1,
+            self.eul_grid_size_y // 2 - 1 + self.num_lag_nodes,
+        ).astype(int)
+        self.lag_positions = (
+            self.nearest_eul_grid_index_to_lag_grid * self.eul_grid_dx
+            + self.eul_grid_coord_shift
+        ).astype(self.real_t)
+
+        # 1. Compute reference interpolation zone support for the lag. grid
+        self.local_eul_grid_support_of_lag_grid = np.zeros(
+            (
+                self.grid_dim,
+                2 * self.interp_kernel_width,
+                2 * self.interp_kernel_width,
+                self.num_lag_nodes,
+            )
+        ).astype(self.real_t)
+        self.eul_lag_communicator.local_eulerian_grid_support_of_lagrangian_grid_kernel(
+            self.local_eul_grid_support_of_lag_grid,
+            self.nearest_eul_grid_index_to_lag_grid,
+            self.lag_positions,
+        )
+
+        # 2. Compute reference interpolation weights
+        self.interp_weights = np.zeros(
+            (
+                2 * self.interp_kernel_width,
+                2 * self.interp_kernel_width,
+                self.num_lag_nodes,
+            ),
+            dtype=self.real_t,
+        )
+        self.mock_local_eul_grid_support_of_lag_grid = (
+            self.local_eul_grid_support_of_lag_grid.copy()
+        )
+        self.eul_lag_communicator.interpolation_weights_kernel(
+            self.interp_weights, self.mock_local_eul_grid_support_of_lag_grid
+        )
+
+        # 3. Compute reference lagrangian grid interpolated from mock eulerian grid
+        if self.n_components == 1:
+            self.lag_grid_field = np.zeros((self.num_lag_nodes), dtype=self.real_t)
+            self.mock_eul_grid_field_prefactor = self.real_t(2.0)
+            self.mock_eul_grid_field = self.mock_eul_grid_field_prefactor * np.ones(
+                (self.eul_grid_size_y, self.eul_grid_size_x), dtype=self.real_t
+            )
+        else:
+            self.lag_grid_field = np.zeros(
+                (self.n_components, self.num_lag_nodes), dtype=self.real_t
+            )
+            self.mock_eul_grid_field_prefactor_x = self.real_t(2.0)
+            self.mock_eul_grid_field_prefactor_y = self.real_t(2.0)
+            self.mock_eul_grid_field = np.ones(
+                (self.n_components, self.eul_grid_size_y, self.eul_grid_size_x),
+                dtype=self.real_t,
+            )
+            self.mock_eul_grid_field[0] *= self.mock_eul_grid_field_prefactor_y
+            self.mock_eul_grid_field[1] *= self.mock_eul_grid_field_prefactor_x
+        self.eul_lag_communicator.eulerian_to_lagrangian_grid_interpolation_kernel(
+            self.lag_grid_field,
+            self.mock_eul_grid_field,
+            self.interp_weights,
+            self.nearest_eul_grid_index_to_lag_grid,
+        )
+
+        # 4. Compute reference eulerian grid interpolated from mock lagrangian grid
+        if self.n_components == 1:
+            prefactor_lag_field = 2
+            self.mock_lag_grid_field = prefactor_lag_field * np.ones(
+                (self.num_lag_nodes), dtype=self.real_t
+            )
+            self.eul_grid_field = np.zeros(
+                (self.eul_grid_size_y, self.eul_grid_size_x), dtype=self.real_t
+            )
+        else:
+            prefactor_lag_field_y = 2
+            prefactor_lag_field_x = 3
+            self.mock_lag_grid_field = np.ones(
+                (self.n_components, self.num_lag_nodes), dtype=self.real_t
+            )
+            self.mock_lag_grid_field[0] *= prefactor_lag_field_y
+            self.mock_lag_grid_field[1] *= prefactor_lag_field_x
+            self.eul_grid_field = np.zeros(
+                (self.n_components, self.eul_grid_size_y, self.eul_grid_size_x),
+                dtype=self.real_t,
+            )
+
+        self.eul_lag_communicator.lagrangian_to_eulerian_grid_interpolation_kernel(
+            self.eul_grid_field,
+            self.mock_lag_grid_field,
+            self.interp_weights,
+            self.nearest_eul_grid_index_to_lag_grid,
+        )
+
+
 @pytest.mark.mpi(group="MPI_immersed_boundary_ops_2d", min_size=4)
 @pytest.mark.parametrize("ghost_size", [1, 2, 3])
 @pytest.mark.parametrize("precision", ["single", "double"])
@@ -19,84 +165,43 @@ from sopht.utils.precision import get_real_t, get_test_tol
 def test_mpi_local_eulerian_grid_support_of_lagrangian_grid_2d(
     ghost_size, precision, rank_distribution, aspect_ratio
 ):
-    n_values = 32
-    real_t = get_real_t(precision)
-    grid_dim = 2
-    eul_grid_size_y = n_values * aspect_ratio[0]
-    eul_grid_size_x = n_values * aspect_ratio[1]
-    eul_grid_size = eul_grid_size_x
-    eul_domain_size = real_t(1.0)
-    eul_grid_dx = real_t(eul_domain_size / eul_grid_size)
-    eul_grid_coord_shift = real_t(0.5 * eul_grid_dx)
-    interp_kernel_width = 2
-    num_lag_nodes = 3
-
-    # 1. Generate reference solution from sopht-backend
-    eul_lag_communicator = EulerianLagrangianGridCommunicator2D(
-        dx=eul_grid_dx,
-        eul_grid_coord_shift=eul_grid_coord_shift,
-        num_lag_nodes=num_lag_nodes,
-        interp_kernel_width=interp_kernel_width,
-        real_t=real_t,
-    )
-    # init lag. grid around center of the domain
-    # this allows testing for the case where rank on first and last quarter (when there
-    # are 4 processes) does not contain any lagrangian nodes AND when the point lies at
-    # the boundary of MPI domain decomposition
-    ref_nearest_eul_grid_index_to_lag_grid = np.empty((grid_dim, num_lag_nodes)).astype(
-        int
-    )
-    ref_nearest_eul_grid_index_to_lag_grid[0] = np.arange(
-        eul_grid_size_x // 2 - 1, eul_grid_size_x // 2 - 1 + num_lag_nodes
-    ).astype(int)
-    ref_nearest_eul_grid_index_to_lag_grid[1] = np.arange(
-        eul_grid_size_y // 2 - 1, eul_grid_size_y // 2 - 1 + num_lag_nodes
-    ).astype(int)
-    ref_lag_positions = (
-        ref_nearest_eul_grid_index_to_lag_grid * eul_grid_dx + eul_grid_coord_shift
-    ).astype(real_t)
-
-    # find interpolation zone support for the lag. grid
-    ref_local_eul_grid_support_of_lag_grid = np.zeros(
-        (grid_dim, 2 * interp_kernel_width, 2 * interp_kernel_width, num_lag_nodes)
-    ).astype(real_t)
-    eul_lag_communicator.local_eulerian_grid_support_of_lagrangian_grid_kernel(
-        ref_local_eul_grid_support_of_lag_grid,
-        ref_nearest_eul_grid_index_to_lag_grid,
-        ref_lag_positions,
+    # 1. Generate reference solution (the solution is in the global domain, and each of
+    # the ranks has the same reference copy)
+    mock_soln = MockEulLagGridCommSolution(
+        n_values=32, aspect_ratio=aspect_ratio, precision=precision
     )
 
     # 2. Initialize MPI related stuff
     # Generate the MPI topology minimal object
     mpi_construct = MPIConstruct2D(
-        grid_size_y=eul_grid_size_y,
-        grid_size_x=eul_grid_size_x,
-        real_t=real_t,
+        grid_size_y=mock_soln.eul_grid_size_y,
+        grid_size_x=mock_soln.eul_grid_size_x,
+        real_t=mock_soln.real_t,
         rank_distribution=rank_distribution,
     )
 
     # Lagrangian grid inter-rank MPI communicator
     master_rank = 0
     mpi_lagrangian_field_communicator = MPILagrangianFieldCommunicator2D(
-        eul_grid_dx=eul_grid_dx,
-        eul_grid_shift=eul_grid_coord_shift,
+        eul_grid_dx=mock_soln.eul_grid_dx,
+        eul_grid_shift=mock_soln.eul_grid_coord_shift,
         mpi_construct=mpi_construct,
         master_rank=master_rank,
-        real_t=real_t,
+        real_t=mock_soln.real_t,
     )
     # Map lagrangian nodes to ranks
     mpi_lagrangian_field_communicator.map_lagrangian_nodes_based_on_position(
-        ref_lag_positions
+        mock_soln.lag_positions
     )
     rank_address = mpi_lagrangian_field_communicator.rank_address
 
     # Initialize Eulerian-Lagrangian grid numerics communicator based on mpi local eul
     # grid coord shift
     mpi_eul_lag_communicator = EulerianLagrangianGridCommunicatorMPI2D(
-        dx=eul_grid_dx,
-        eul_grid_coord_shift=eul_grid_coord_shift,
-        interp_kernel_width=interp_kernel_width,
-        real_t=real_t,
+        dx=mock_soln.eul_grid_dx,
+        eul_grid_coord_shift=mock_soln.eul_grid_coord_shift,
+        interp_kernel_width=mock_soln.interp_kernel_width,
+        real_t=mock_soln.real_t,
         mpi_construct=mpi_construct,
         ghost_size=ghost_size,
     )
@@ -105,18 +210,18 @@ def test_mpi_local_eulerian_grid_support_of_lagrangian_grid_2d(
     # since all the ranks have the same reference solution, we can just mask them out
     # the "mpi rank local" data after mapping the lag nodes to their respective ranks
     mask = np.where(rank_address == mpi_lagrangian_field_communicator.rank)[0]
-    mpi_local_lag_positions = ref_lag_positions[..., mask]
+    mpi_local_lag_positions = mock_soln.lag_positions[..., mask]
     mpi_local_nearest_eul_grid_index_to_lag_grid = np.zeros(
-        (grid_dim, mpi_lagrangian_field_communicator.local_num_lag_nodes)
+        (mock_soln.grid_dim, mpi_lagrangian_field_communicator.local_num_lag_nodes)
     ).astype(int)
     mpi_local_local_eul_grid_support_of_lag_grid = np.zeros(
         (
-            grid_dim,
-            2 * interp_kernel_width,
-            2 * interp_kernel_width,
+            mock_soln.grid_dim,
+            2 * mock_soln.interp_kernel_width,
+            2 * mock_soln.interp_kernel_width,
             mpi_lagrangian_field_communicator.local_num_lag_nodes,
         )
-    ).astype(real_t)
+    ).astype(mock_soln.real_t)
 
     mpi_eul_lag_communicator.local_eulerian_grid_support_of_lagrangian_grid_kernel(
         mpi_local_local_eul_grid_support_of_lag_grid,
@@ -130,17 +235,17 @@ def test_mpi_local_eulerian_grid_support_of_lagrangian_grid_2d(
     mpi_local_nearest_eul_grid_index_to_lag_grid = (
         mpi_local_nearest_eul_grid_index_to_lag_grid
         - ghost_size
-        + mpi_substart_idx.reshape(grid_dim, 1)
+        + mpi_substart_idx.reshape(mock_soln.grid_dim, 1)
     ).astype(int)
 
     # 4. Test and compare values
     np.testing.assert_allclose(
-        ref_nearest_eul_grid_index_to_lag_grid[..., mask],
+        mock_soln.nearest_eul_grid_index_to_lag_grid[..., mask],
         mpi_local_nearest_eul_grid_index_to_lag_grid,
         atol=get_test_tol(precision),
     )
     np.testing.assert_allclose(
-        ref_local_eul_grid_support_of_lag_grid[..., mask],
+        mock_soln.local_eul_grid_support_of_lag_grid[..., mask],
         mpi_local_local_eul_grid_support_of_lag_grid,
         atol=get_test_tol(precision),
     )
@@ -154,92 +259,43 @@ def test_mpi_local_eulerian_grid_support_of_lagrangian_grid_2d(
 def test_mpi_eulerian_to_lagrangian_grid_interpolation_kernel_2d(
     ghost_size, precision, rank_distribution, aspect_ratio
 ):
-    n_values = 32
-    real_t = get_real_t(precision)
-    grid_dim = 2
-    eul_grid_size_y = n_values * aspect_ratio[0]
-    eul_grid_size_x = n_values * aspect_ratio[1]
-    eul_grid_size = eul_grid_size_x
-    eul_domain_size = real_t(1.0)
-    eul_grid_dx = real_t(eul_domain_size / eul_grid_size)
-    eul_grid_coord_shift = real_t(0.5 * eul_grid_dx)
-    interp_kernel_width = 2
-    num_lag_nodes = 3
-
-    # 1. Generate reference solution from sopht-backend
-    eul_lag_communicator = EulerianLagrangianGridCommunicator2D(
-        dx=eul_grid_dx,
-        eul_grid_coord_shift=eul_grid_coord_shift,
-        num_lag_nodes=num_lag_nodes,
-        interp_kernel_width=interp_kernel_width,
-        real_t=real_t,
-    )
-    eulerian_to_lagrangian_grid_interpolation_kernel = (
-        eul_lag_communicator.eulerian_to_lagrangian_grid_interpolation_kernel
-    )
-    # init lag. grid around center of the domain
-    # this allows testing for the case where rank on first and last quarter (when there
-    # are 4 processes) does not contain any lagrangian nodes AND when the point lies at
-    # the boundary of MPI domain decomposition
-    ref_nearest_eul_grid_index_to_lag_grid = np.empty((grid_dim, num_lag_nodes)).astype(
-        int
-    )
-    ref_nearest_eul_grid_index_to_lag_grid[0] = np.arange(
-        eul_grid_size_x // 2 - 1, eul_grid_size_x // 2 - 1 + num_lag_nodes
-    ).astype(int)
-    ref_nearest_eul_grid_index_to_lag_grid[1] = np.arange(
-        eul_grid_size_y // 2 - 1, eul_grid_size_y // 2 - 1 + num_lag_nodes
-    ).astype(int)
-    ref_lag_positions = (
-        ref_nearest_eul_grid_index_to_lag_grid * eul_grid_dx + eul_grid_coord_shift
-    ).astype(real_t)
-    # set interp weight as a series of 0 to 4 * interp_kernel_width ** 2 - 1
-    ref_interp_weights = np.arange(0, 4 * interp_kernel_width**2).reshape(
-        2 * interp_kernel_width, 2 * interp_kernel_width, 1
-    )
-    ref_interp_weights = np.tile(ref_interp_weights, reps=(1, 1, num_lag_nodes)).astype(
-        real_t
-    )
-    ref_lag_grid_field = np.zeros((num_lag_nodes), dtype=real_t)
-    ref_eul_grid_field = np.ones((eul_grid_size_y, eul_grid_size_x), dtype=real_t)
-    eulerian_to_lagrangian_grid_interpolation_kernel(
-        ref_lag_grid_field,
-        ref_eul_grid_field,
-        ref_interp_weights,
-        ref_nearest_eul_grid_index_to_lag_grid,
+    # 1. Generate reference solution (the solution is in the global domain, and each of
+    # the ranks has the same reference copy)
+    mock_soln = MockEulLagGridCommSolution(
+        n_values=32, aspect_ratio=aspect_ratio, precision=precision
     )
 
     # 2. Initialize MPI related stuff
     # Generate the MPI topology minimal object
     mpi_construct = MPIConstruct2D(
-        grid_size_y=eul_grid_size_y,
-        grid_size_x=eul_grid_size_x,
-        real_t=real_t,
+        grid_size_y=mock_soln.eul_grid_size_y,
+        grid_size_x=mock_soln.eul_grid_size_x,
+        real_t=mock_soln.real_t,
         rank_distribution=rank_distribution,
     )
 
     # Lagrangian grid inter-rank MPI communicator
     master_rank = 0
     mpi_lagrangian_field_communicator = MPILagrangianFieldCommunicator2D(
-        eul_grid_dx=eul_grid_dx,
-        eul_grid_shift=eul_grid_coord_shift,
+        eul_grid_dx=mock_soln.eul_grid_dx,
+        eul_grid_shift=mock_soln.eul_grid_coord_shift,
         mpi_construct=mpi_construct,
         master_rank=master_rank,
-        real_t=real_t,
+        real_t=mock_soln.real_t,
     )
     # Map lagrangian nodes to ranks
     mpi_lagrangian_field_communicator.map_lagrangian_nodes_based_on_position(
-        ref_lag_positions
+        mock_soln.lag_positions
     )
     rank_address = mpi_lagrangian_field_communicator.rank_address
 
     # Initialize Eulerian-Lagrangian grid numerics communicator based on mpi local eul
     # grid coord shift
     mpi_eul_lag_communicator = EulerianLagrangianGridCommunicatorMPI2D(
-        dx=eul_grid_dx,
-        eul_grid_coord_shift=eul_grid_coord_shift,
-        interp_kernel_width=interp_kernel_width,
-        real_t=real_t,
+        dx=mock_soln.eul_grid_dx,
+        eul_grid_coord_shift=mock_soln.eul_grid_coord_shift,
+        interp_kernel_width=mock_soln.interp_kernel_width,
+        real_t=mock_soln.real_t,
         mpi_construct=mpi_construct,
         ghost_size=ghost_size,
     )
@@ -249,18 +305,19 @@ def test_mpi_eulerian_to_lagrangian_grid_interpolation_kernel_2d(
     # the "mpi rank local" data after mapping the lag nodes to their respective ranks
     mask = np.where(rank_address == mpi_lagrangian_field_communicator.rank)[0]
     mpi_local_eul_grid_field = np.ones(
-        mpi_construct.local_grid_size + 2 * ghost_size, dtype=real_t
+        mpi_construct.local_grid_size + 2 * ghost_size, dtype=mock_soln.real_t
     )
-    mpi_local_interp_weights = ref_interp_weights[..., mask]
+    mpi_local_eul_grid_field *= mock_soln.mock_eul_grid_field_prefactor
+    mpi_local_interp_weights = mock_soln.interp_weights[..., mask]
     # indices needs to be offset with mpi local reference index
     mpi_substart_idx = mpi_eul_lag_communicator.mpi_substart_idx
     mpi_local_nearest_eul_grid_index_to_lag_grid = (
-        ref_nearest_eul_grid_index_to_lag_grid[..., mask]
+        mock_soln.nearest_eul_grid_index_to_lag_grid[..., mask]
         + ghost_size
-        - mpi_substart_idx.reshape(grid_dim, 1)
+        - mpi_substart_idx.reshape(mock_soln.grid_dim, 1)
     )
     mpi_local_lag_grid_field = np.zeros(
-        (mpi_lagrangian_field_communicator.local_num_lag_nodes), dtype=real_t
+        (mpi_lagrangian_field_communicator.local_num_lag_nodes), dtype=mock_soln.real_t
     )
     mpi_eul_lag_communicator.eulerian_to_lagrangian_grid_interpolation_kernel(
         mpi_local_lag_grid_field,
@@ -270,7 +327,7 @@ def test_mpi_eulerian_to_lagrangian_grid_interpolation_kernel_2d(
     )
 
     np.testing.assert_allclose(
-        ref_lag_grid_field[..., mask],
+        mock_soln.lag_grid_field[..., mask],
         mpi_local_lag_grid_field,
         atol=get_test_tol(precision),
     )
@@ -284,97 +341,44 @@ def test_mpi_eulerian_to_lagrangian_grid_interpolation_kernel_2d(
 def test_mpi_vector_field_eul_to_lag_grid_interpolation_kernel_2d(
     ghost_size, precision, rank_distribution, aspect_ratio
 ):
-    n_values = 32
-    real_t = get_real_t(precision)
-    grid_dim = 2
-    n_components = grid_dim
-    eul_grid_size_y = n_values * aspect_ratio[0]
-    eul_grid_size_x = n_values * aspect_ratio[1]
-    eul_grid_size = eul_grid_size_x
-    eul_domain_size = real_t(1.0)
-    eul_grid_dx = real_t(eul_domain_size / eul_grid_size)
-    eul_grid_coord_shift = real_t(0.5 * eul_grid_dx)
-    interp_kernel_width = 2
-    num_lag_nodes = 3
-
-    # 1. Generate reference solution from sopht-backend
-    eul_lag_communicator = EulerianLagrangianGridCommunicator2D(
-        dx=eul_grid_dx,
-        eul_grid_coord_shift=eul_grid_coord_shift,
-        num_lag_nodes=num_lag_nodes,
-        interp_kernel_width=interp_kernel_width,
-        n_components=2,
-        real_t=real_t,
-    )
-    eulerian_to_lagrangian_grid_interpolation_kernel = (
-        eul_lag_communicator.eulerian_to_lagrangian_grid_interpolation_kernel
-    )
-    # init lag. grid around center of the domain
-    # this allows testing for the case where rank on first and last quarter (when there
-    # are 4 processes) does not contain any lagrangian nodes AND when the point lies at
-    # the boundary of MPI domain decomposition
-    ref_nearest_eul_grid_index_to_lag_grid = np.empty((grid_dim, num_lag_nodes)).astype(
-        int
-    )
-    ref_nearest_eul_grid_index_to_lag_grid[0] = np.arange(
-        eul_grid_size_x // 2 - 1, eul_grid_size_x // 2 - 1 + num_lag_nodes
-    ).astype(int)
-    ref_nearest_eul_grid_index_to_lag_grid[1] = np.arange(
-        eul_grid_size_y // 2 - 1, eul_grid_size_y // 2 - 1 + num_lag_nodes
-    ).astype(int)
-    ref_lag_positions = (
-        ref_nearest_eul_grid_index_to_lag_grid * eul_grid_dx + eul_grid_coord_shift
-    ).astype(real_t)
-    # set interp weight as a series of 0 to 4 * interp_kernel_width ** 2 - 1
-    ref_interp_weights = np.arange(0, 4 * interp_kernel_width**2).reshape(
-        2 * interp_kernel_width, 2 * interp_kernel_width, 1
-    )
-    ref_interp_weights = np.tile(ref_interp_weights, reps=(1, 1, num_lag_nodes)).astype(
-        real_t
-    )
-    ref_lag_grid_field = np.zeros((n_components, num_lag_nodes), dtype=real_t)
-    ref_eul_grid_field = np.ones(
-        (n_components, eul_grid_size_y, eul_grid_size_x), dtype=real_t
-    )
-    eulerian_to_lagrangian_grid_interpolation_kernel(
-        ref_lag_grid_field,
-        ref_eul_grid_field,
-        ref_interp_weights,
-        ref_nearest_eul_grid_index_to_lag_grid,
+    # 1. Generate reference solution (the solution is in the global domain, and each of
+    # the ranks has the same reference copy)
+    mock_soln = MockEulLagGridCommSolution(
+        n_values=32, aspect_ratio=aspect_ratio, precision=precision, n_components=2
     )
 
     # 2. Initialize MPI related stuff
     # Generate the MPI topology minimal object
     mpi_construct = MPIConstruct2D(
-        grid_size_y=eul_grid_size_y,
-        grid_size_x=eul_grid_size_x,
-        real_t=real_t,
+        grid_size_y=mock_soln.eul_grid_size_y,
+        grid_size_x=mock_soln.eul_grid_size_x,
+        real_t=mock_soln.real_t,
         rank_distribution=rank_distribution,
     )
 
     # Lagrangian grid inter-rank MPI communicator
     master_rank = 0
     mpi_lagrangian_field_communicator = MPILagrangianFieldCommunicator2D(
-        eul_grid_dx=eul_grid_dx,
-        eul_grid_shift=eul_grid_coord_shift,
+        eul_grid_dx=mock_soln.eul_grid_dx,
+        eul_grid_shift=mock_soln.eul_grid_coord_shift,
         mpi_construct=mpi_construct,
         master_rank=master_rank,
-        real_t=real_t,
+        real_t=mock_soln.real_t,
     )
     # Map lagrangian nodes to ranks
     mpi_lagrangian_field_communicator.map_lagrangian_nodes_based_on_position(
-        ref_lag_positions
+        mock_soln.lag_positions
     )
     rank_address = mpi_lagrangian_field_communicator.rank_address
 
     # Initialize Eulerian-Lagrangian grid numerics communicator based on mpi local eul
     # grid coord shift
     mpi_eul_lag_communicator = EulerianLagrangianGridCommunicatorMPI2D(
-        dx=eul_grid_dx,
-        eul_grid_coord_shift=eul_grid_coord_shift,
-        interp_kernel_width=interp_kernel_width,
+        dx=mock_soln.eul_grid_dx,
+        eul_grid_coord_shift=mock_soln.eul_grid_coord_shift,
+        interp_kernel_width=mock_soln.interp_kernel_width,
         n_components=2,
-        real_t=real_t,
+        real_t=mock_soln.real_t,
         mpi_construct=mpi_construct,
         ghost_size=ghost_size,
     )
@@ -385,23 +389,25 @@ def test_mpi_vector_field_eul_to_lag_grid_interpolation_kernel_2d(
     mask = np.where(rank_address == mpi_lagrangian_field_communicator.rank)[0]
     mpi_local_eul_grid_field = np.ones(
         (
-            n_components,
+            mock_soln.n_components,
             mpi_construct.local_grid_size[0] + 2 * ghost_size,
             mpi_construct.local_grid_size[1] + 2 * ghost_size,
         ),
-        dtype=real_t,
+        dtype=mock_soln.real_t,
     )
-    mpi_local_interp_weights = ref_interp_weights[..., mask]
+    mpi_local_eul_grid_field[0] *= mock_soln.mock_eul_grid_field_prefactor_y
+    mpi_local_eul_grid_field[1] *= mock_soln.mock_eul_grid_field_prefactor_x
+    mpi_local_interp_weights = mock_soln.interp_weights[..., mask]
     # indices needs to be offset with mpi local reference index
     mpi_substart_idx = mpi_eul_lag_communicator.mpi_substart_idx
     mpi_local_nearest_eul_grid_index_to_lag_grid = (
-        ref_nearest_eul_grid_index_to_lag_grid[..., mask]
+        mock_soln.nearest_eul_grid_index_to_lag_grid[..., mask]
         + ghost_size
-        - mpi_substart_idx.reshape(grid_dim, 1)
+        - mpi_substart_idx.reshape(mock_soln.grid_dim, 1)
     )
     mpi_local_lag_grid_field = np.zeros(
-        (n_components, mpi_lagrangian_field_communicator.local_num_lag_nodes),
-        dtype=real_t,
+        (mock_soln.n_components, mpi_lagrangian_field_communicator.local_num_lag_nodes),
+        dtype=mock_soln.real_t,
     )
     mpi_eul_lag_communicator.eulerian_to_lagrangian_grid_interpolation_kernel(
         mpi_local_lag_grid_field,
@@ -411,7 +417,7 @@ def test_mpi_vector_field_eul_to_lag_grid_interpolation_kernel_2d(
     )
 
     np.testing.assert_allclose(
-        ref_lag_grid_field[..., mask],
+        mock_soln.lag_grid_field[..., mask],
         mpi_local_lag_grid_field,
         atol=get_test_tol(precision),
     )
@@ -428,93 +434,43 @@ def test_mpi_lagrangian_to_eulerian_grid_interpolation_kernel_2d(
     rank_distribution,
     aspect_ratio,
 ):
-    n_values = 32
-    real_t = get_real_t(precision)
-    grid_dim = 2
-    eul_grid_size_y = n_values * aspect_ratio[0]
-    eul_grid_size_x = n_values * aspect_ratio[1]
-    eul_grid_size = eul_grid_size_x
-    eul_domain_size = real_t(1.0)
-    eul_grid_dx = real_t(eul_domain_size / eul_grid_size)
-    eul_grid_coord_shift = real_t(0.5 * eul_grid_dx)
-    interp_kernel_width = 2
-    num_lag_nodes = 3
-
-    # 1. Generate reference solution from sopht-backend
-    eul_lag_communicator = EulerianLagrangianGridCommunicator2D(
-        dx=eul_grid_dx,
-        eul_grid_coord_shift=eul_grid_coord_shift,
-        num_lag_nodes=num_lag_nodes,
-        interp_kernel_width=interp_kernel_width,
-        real_t=real_t,
-    )
-    lagrangian_to_eulerian_grid_interpolation_kernel = (
-        eul_lag_communicator.lagrangian_to_eulerian_grid_interpolation_kernel
-    )
-    # init lag. grid around center of the domain
-    # this allows testing for the case where rank on first and last quarter (when there
-    # are 4 processes) does not contain any lagrangian nodes AND when the points lie
-    # close to the boundary of MPI domain decomposition
-    ref_nearest_eul_grid_index_to_lag_grid = np.empty((grid_dim, num_lag_nodes)).astype(
-        int
-    )
-    ref_nearest_eul_grid_index_to_lag_grid[0] = np.arange(
-        eul_grid_size_x // 2 - 1, eul_grid_size_x // 2 - 1 + num_lag_nodes
-    ).astype(int)
-    ref_nearest_eul_grid_index_to_lag_grid[1] = np.arange(
-        eul_grid_size_y // 2 - 1, eul_grid_size_y // 2 - 1 + num_lag_nodes
-    ).astype(int)
-    # need ref lag positions to get rank address later
-    ref_lag_positions = (
-        ref_nearest_eul_grid_index_to_lag_grid * eul_grid_dx + eul_grid_coord_shift
-    ).astype(real_t)
-    # init interp weights as all ones, essentially this should lead to
-    # interpolation spreading ones onto the Eulerian grid
-    ref_interp_weights = np.ones(
-        (2 * interp_kernel_width, 2 * interp_kernel_width, num_lag_nodes),
-        dtype=real_t,
-    )
-    prefactor_lag_field = 2
-    ref_lag_grid_field = prefactor_lag_field * np.ones((num_lag_nodes), dtype=real_t)
-    ref_eul_grid_field = np.zeros((eul_grid_size_y, eul_grid_size_x), dtype=real_t)
-    lagrangian_to_eulerian_grid_interpolation_kernel(
-        ref_eul_grid_field,
-        ref_lag_grid_field,
-        ref_interp_weights,
-        ref_nearest_eul_grid_index_to_lag_grid,
+    # 1. Generate reference solution (the solution is in the global domain, and each of
+    # the ranks has the same reference copy)
+    mock_soln = MockEulLagGridCommSolution(
+        n_values=32, aspect_ratio=aspect_ratio, precision=precision
     )
 
     # 2. Initialize MPI related stuff
     # Generate the MPI topology minimal object
     mpi_construct = MPIConstruct2D(
-        grid_size_y=eul_grid_size_y,
-        grid_size_x=eul_grid_size_x,
-        real_t=real_t,
+        grid_size_y=mock_soln.eul_grid_size_y,
+        grid_size_x=mock_soln.eul_grid_size_x,
+        real_t=mock_soln.real_t,
         rank_distribution=rank_distribution,
     )
 
     # Lagrangian grid inter-rank MPI communicator
     master_rank = 0
     mpi_lagrangian_field_communicator = MPILagrangianFieldCommunicator2D(
-        eul_grid_dx=eul_grid_dx,
-        eul_grid_shift=eul_grid_coord_shift,
+        eul_grid_dx=mock_soln.eul_grid_dx,
+        eul_grid_shift=mock_soln.eul_grid_coord_shift,
         mpi_construct=mpi_construct,
         master_rank=master_rank,
-        real_t=real_t,
+        real_t=mock_soln.real_t,
     )
     # Map lagrangian nodes to ranks
     mpi_lagrangian_field_communicator.map_lagrangian_nodes_based_on_position(
-        ref_lag_positions
+        mock_soln.lag_positions
     )
     rank_address = mpi_lagrangian_field_communicator.rank_address
 
     # Initialize Eulerian-Lagrangian grid numerics communicator based on mpi local eul
     # grid coord shift
     mpi_eul_lag_communicator = EulerianLagrangianGridCommunicatorMPI2D(
-        dx=eul_grid_dx,
-        eul_grid_coord_shift=eul_grid_coord_shift,
-        interp_kernel_width=interp_kernel_width,
-        real_t=real_t,
+        dx=mock_soln.eul_grid_dx,
+        eul_grid_coord_shift=mock_soln.eul_grid_coord_shift,
+        interp_kernel_width=mock_soln.interp_kernel_width,
+        real_t=mock_soln.real_t,
         mpi_construct=mpi_construct,
         ghost_size=ghost_size,
     )
@@ -524,16 +480,16 @@ def test_mpi_lagrangian_to_eulerian_grid_interpolation_kernel_2d(
     # the "mpi rank local" data after mapping the lag nodes to their respective ranks
     mask = np.where(rank_address == mpi_lagrangian_field_communicator.rank)[0]
     mpi_local_eul_grid_field = np.zeros(
-        mpi_construct.local_grid_size + 2 * ghost_size, dtype=real_t
+        mpi_construct.local_grid_size + 2 * ghost_size, dtype=mock_soln.real_t
     )
-    mpi_local_lag_grid_field = ref_lag_grid_field[..., mask]
-    mpi_local_interp_weights = ref_interp_weights[..., mask]
+    mpi_local_lag_grid_field = mock_soln.mock_lag_grid_field[..., mask]
+    mpi_local_interp_weights = mock_soln.interp_weights[..., mask]
     # indices needs to be offset with mpi local reference index
     mpi_substart_idx = mpi_eul_lag_communicator.mpi_substart_idx
     mpi_local_nearest_eul_grid_index_to_lag_grid = (
-        ref_nearest_eul_grid_index_to_lag_grid[..., mask]
+        mock_soln.nearest_eul_grid_index_to_lag_grid[..., mask]
         + ghost_size
-        - mpi_substart_idx.reshape(grid_dim, 1)
+        - mpi_substart_idx.reshape(mock_soln.grid_dim, 1)
     )
 
     mpi_eul_lag_communicator.lagrangian_to_eulerian_grid_interpolation_kernel(
@@ -554,7 +510,7 @@ def test_mpi_lagrangian_to_eulerian_grid_interpolation_kernel_2d(
     )
 
     np.testing.assert_allclose(
-        ref_eul_grid_field[mpi_local_sol_idx],
+        mock_soln.eul_grid_field[mpi_local_sol_idx],
         mpi_local_eul_grid_field[ghost_size:-ghost_size, ghost_size:-ghost_size],
         atol=get_test_tol(precision),
     )
@@ -571,103 +527,46 @@ def test_mpi_vector_field_lag_to_eul_grid_interpolation_kernel_2d(
     rank_distribution,
     aspect_ratio,
 ):
-    n_values = 32
-    real_t = get_real_t(precision)
-    grid_dim = 2
-    n_components = grid_dim
-    eul_grid_size_y = n_values * aspect_ratio[0]
-    eul_grid_size_x = n_values * aspect_ratio[1]
-    eul_grid_size = eul_grid_size_x
-    eul_domain_size = real_t(1.0)
-    eul_grid_dx = real_t(eul_domain_size / eul_grid_size)
-    eul_grid_coord_shift = real_t(0.5 * eul_grid_dx)
-    interp_kernel_width = 2
-    num_lag_nodes = 3
-
-    # 1. Generate reference solution from sopht-backend
-    eul_lag_communicator = EulerianLagrangianGridCommunicator2D(
-        dx=eul_grid_dx,
-        eul_grid_coord_shift=eul_grid_coord_shift,
-        num_lag_nodes=num_lag_nodes,
-        interp_kernel_width=interp_kernel_width,
-        real_t=real_t,
-        n_components=n_components,
-    )
-    lagrangian_to_eulerian_grid_interpolation_kernel = (
-        eul_lag_communicator.lagrangian_to_eulerian_grid_interpolation_kernel
-    )
-    # init lag. grid around center of the domain
-    # this allows testing for the case where rank on first and last quarter (when there
-    # are 4 processes) does not contain any lagrangian nodes AND when the point lies at
-    # the boundary of MPI domain decomposition
-    ref_nearest_eul_grid_index_to_lag_grid = np.empty((grid_dim, num_lag_nodes)).astype(
-        int
-    )
-    ref_nearest_eul_grid_index_to_lag_grid[0] = np.arange(
-        eul_grid_size_x // 2 - 1, eul_grid_size_x // 2 - 1 + num_lag_nodes
-    ).astype(int)
-    ref_nearest_eul_grid_index_to_lag_grid[1] = np.arange(
-        eul_grid_size_y // 2 - 1, eul_grid_size_y // 2 - 1 + num_lag_nodes
-    ).astype(int)
-    # need ref lag positions to get rank address later
-    ref_lag_positions = (
-        ref_nearest_eul_grid_index_to_lag_grid * eul_grid_dx + eul_grid_coord_shift
-    ).astype(real_t)
-    # init interp weights as all ones, essentially this should lead to
-    # interpolation spreading ones onto the Eulerian grid
-    ref_interp_weights = np.ones(
-        (2 * interp_kernel_width, 2 * interp_kernel_width, num_lag_nodes),
-        dtype=real_t,
-    )
-    prefactor_lag_field_y = 2
-    prefactor_lag_field_x = 3
-    ref_lag_grid_field = np.ones((n_components, num_lag_nodes), dtype=real_t)
-    ref_lag_grid_field[0] *= prefactor_lag_field_y
-    ref_lag_grid_field[1] *= prefactor_lag_field_x
-    ref_eul_grid_field = np.zeros(
-        (n_components, eul_grid_size_y, eul_grid_size_x), dtype=real_t
-    )
-    lagrangian_to_eulerian_grid_interpolation_kernel(
-        ref_eul_grid_field,
-        ref_lag_grid_field,
-        ref_interp_weights,
-        ref_nearest_eul_grid_index_to_lag_grid,
+    # 1. Generate reference solution (the solution is in the global domain, and each of
+    # the ranks has the same reference copy)
+    mock_soln = MockEulLagGridCommSolution(
+        n_values=32, aspect_ratio=aspect_ratio, precision=precision, n_components=2
     )
 
     # 2. Initialize MPI related stuff
     # Generate the MPI topology minimal object
     mpi_construct = MPIConstruct2D(
-        grid_size_y=eul_grid_size_y,
-        grid_size_x=eul_grid_size_x,
-        real_t=real_t,
+        grid_size_y=mock_soln.eul_grid_size_y,
+        grid_size_x=mock_soln.eul_grid_size_x,
+        real_t=mock_soln.real_t,
         rank_distribution=rank_distribution,
     )
 
     # Lagrangian grid inter-rank MPI communicator
     master_rank = 0
     mpi_lagrangian_field_communicator = MPILagrangianFieldCommunicator2D(
-        eul_grid_dx=eul_grid_dx,
-        eul_grid_shift=eul_grid_coord_shift,
+        eul_grid_dx=mock_soln.eul_grid_dx,
+        eul_grid_shift=mock_soln.eul_grid_coord_shift,
         mpi_construct=mpi_construct,
         master_rank=master_rank,
-        real_t=real_t,
+        real_t=mock_soln.real_t,
     )
     # Map lagrangian nodes to ranks
     mpi_lagrangian_field_communicator.map_lagrangian_nodes_based_on_position(
-        ref_lag_positions
+        mock_soln.lag_positions
     )
     rank_address = mpi_lagrangian_field_communicator.rank_address
 
     # Initialize Eulerian-Lagrangian grid numerics communicator based on mpi local eul
     # grid coord shift
     mpi_eul_lag_communicator = EulerianLagrangianGridCommunicatorMPI2D(
-        dx=eul_grid_dx,
-        eul_grid_coord_shift=eul_grid_coord_shift,
-        interp_kernel_width=interp_kernel_width,
-        real_t=real_t,
+        dx=mock_soln.eul_grid_dx,
+        eul_grid_coord_shift=mock_soln.eul_grid_coord_shift,
+        interp_kernel_width=mock_soln.interp_kernel_width,
+        real_t=mock_soln.real_t,
         mpi_construct=mpi_construct,
         ghost_size=ghost_size,
-        n_components=n_components,
+        n_components=mock_soln.n_components,
     )
 
     # 3. Compute solution using MPI implementation
@@ -680,16 +579,16 @@ def test_mpi_vector_field_lag_to_eul_grid_interpolation_kernel_2d(
             mpi_construct.local_grid_size[0] + 2 * ghost_size,
             mpi_construct.local_grid_size[1] + 2 * ghost_size,
         ),
-        dtype=real_t,
+        dtype=mock_soln.real_t,
     )
-    mpi_local_lag_grid_field = ref_lag_grid_field[..., mask]
-    mpi_local_interp_weights = ref_interp_weights[..., mask]
+    mpi_local_lag_grid_field = mock_soln.mock_lag_grid_field[..., mask]
+    mpi_local_interp_weights = mock_soln.interp_weights[..., mask]
     # indices needs to be offset with mpi local reference index
     mpi_substart_idx = mpi_eul_lag_communicator.mpi_substart_idx
     mpi_local_nearest_eul_grid_index_to_lag_grid = (
-        ref_nearest_eul_grid_index_to_lag_grid[..., mask]
+        mock_soln.nearest_eul_grid_index_to_lag_grid[..., mask]
         + ghost_size
-        - mpi_substart_idx.reshape(grid_dim, 1)
+        - mpi_substart_idx.reshape(mock_soln.grid_dim, 1)
     )
 
     mpi_eul_lag_communicator.lagrangian_to_eulerian_grid_interpolation_kernel(
@@ -713,13 +612,13 @@ def test_mpi_vector_field_lag_to_eul_grid_interpolation_kernel_2d(
     )
 
     np.testing.assert_allclose(
-        ref_eul_grid_field[mpi_local_sol_idx],
+        mock_soln.eul_grid_field[mpi_local_sol_idx],
         mpi_local_eul_grid_field[:, ghost_size:-ghost_size, ghost_size:-ghost_size],
         atol=get_test_tol(precision),
     )
 
 
-@pytest.mark.mpi(group="MPI_immersed_boundary_ops_2d", min_size=4)
+@pytest.mark.mpi(group="MPI_immersed_boundary_ops_2d", min_size=8)
 @pytest.mark.parametrize("ghost_size", [1, 2, 3])
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("rank_distribution", [(1, 0), (0, 1)])
@@ -732,93 +631,46 @@ def test_mpi_interpolation_weights_kernel_on_nodes_2d(
     aspect_ratio,
     interp_kernel_type,
 ):
-    n_values = 32
-    real_t = get_real_t(precision)
-    grid_dim = 2
-    eul_grid_size_y = n_values * aspect_ratio[0]
-    eul_grid_size_x = n_values * aspect_ratio[1]
-    eul_grid_size = eul_grid_size_x
-    eul_domain_size = real_t(1.0)
-    eul_grid_dx = real_t(eul_domain_size / eul_grid_size)
-    eul_grid_coord_shift = real_t(0.5 * eul_grid_dx)
-    interp_kernel_width = 2
-    num_lag_nodes = 3
-
-    # 1. Generate reference solution from sopht-backend
-    eul_lag_communicator = EulerianLagrangianGridCommunicator2D(
-        dx=eul_grid_dx,
-        eul_grid_coord_shift=eul_grid_coord_shift,
-        num_lag_nodes=num_lag_nodes,
-        interp_kernel_width=interp_kernel_width,
-        real_t=real_t,
+    # 1. Generate reference solution (the solution is in the global domain, and each of
+    # the ranks has the same reference copy)
+    mock_soln = MockEulLagGridCommSolution(
+        n_values=32,
+        aspect_ratio=aspect_ratio,
+        precision=precision,
         interp_kernel_type=interp_kernel_type,
-    )
-    interpolation_weights_kernel = eul_lag_communicator.interpolation_weights_kernel
-    # init lag. grid around center of the domain
-    # this allows testing for the case where rank on first and last quarter (when there
-    # are 4 processes) does not contain any lagrangian nodes AND when the point lies at
-    # the boundary of MPI domain decomposition
-    ref_nearest_eul_grid_index_to_lag_grid = np.empty((grid_dim, num_lag_nodes)).astype(
-        int
-    )
-    ref_nearest_eul_grid_index_to_lag_grid[0] = np.arange(
-        eul_grid_size_x // 2 - 1, eul_grid_size_x // 2 - 1 + num_lag_nodes
-    ).astype(int)
-    ref_nearest_eul_grid_index_to_lag_grid[1] = np.arange(
-        eul_grid_size_y // 2 - 1, eul_grid_size_y // 2 - 1 + num_lag_nodes
-    ).astype(int)
-    ref_lag_positions = (
-        ref_nearest_eul_grid_index_to_lag_grid * eul_grid_dx + eul_grid_coord_shift
-    ).astype(real_t)
-    # find interpolation zone support for the lag. grid
-    ref_local_eul_grid_support_of_lag_grid = np.zeros(
-        (grid_dim, 2 * interp_kernel_width, 2 * interp_kernel_width, num_lag_nodes)
-    ).astype(real_t)
-    eul_lag_communicator.local_eulerian_grid_support_of_lagrangian_grid_kernel(
-        ref_local_eul_grid_support_of_lag_grid,
-        ref_nearest_eul_grid_index_to_lag_grid,
-        ref_lag_positions,
-    )
-    # compute reference interpolation weights
-    ref_interp_weights = np.zeros(
-        (2 * interp_kernel_width, 2 * interp_kernel_width, num_lag_nodes),
-        dtype=real_t,
-    )
-    interpolation_weights_kernel(
-        ref_interp_weights, ref_local_eul_grid_support_of_lag_grid
     )
 
     # 2. Initialize MPI related stuff
     # Generate the MPI topology minimal object
     mpi_construct = MPIConstruct2D(
-        grid_size_y=eul_grid_size_y,
-        grid_size_x=eul_grid_size_x,
-        real_t=real_t,
+        grid_size_y=mock_soln.eul_grid_size_y,
+        grid_size_x=mock_soln.eul_grid_size_x,
+        real_t=mock_soln.real_t,
         rank_distribution=rank_distribution,
     )
 
     # Lagrangian grid inter-rank MPI communicator
     master_rank = 0
     mpi_lagrangian_field_communicator = MPILagrangianFieldCommunicator2D(
-        eul_grid_dx=eul_grid_dx,
-        eul_grid_shift=eul_grid_coord_shift,
+        eul_grid_dx=mock_soln.eul_grid_dx,
+        eul_grid_shift=mock_soln.eul_grid_coord_shift,
         mpi_construct=mpi_construct,
         master_rank=master_rank,
-        real_t=real_t,
+        real_t=mock_soln.real_t,
     )
     # Map lagrangian nodes to ranks
     mpi_lagrangian_field_communicator.map_lagrangian_nodes_based_on_position(
-        ref_lag_positions
+        mock_soln.lag_positions
     )
     rank_address = mpi_lagrangian_field_communicator.rank_address
 
     # Initialize Eulerian-Lagrangian grid numerics communicator based on mpi local eul
     # grid coord shift
     mpi_eul_lag_communicator = EulerianLagrangianGridCommunicatorMPI2D(
-        dx=eul_grid_dx,
-        eul_grid_coord_shift=eul_grid_coord_shift,
-        interp_kernel_width=interp_kernel_width,
-        real_t=real_t,
+        dx=mock_soln.eul_grid_dx,
+        eul_grid_coord_shift=mock_soln.eul_grid_coord_shift,
+        interp_kernel_width=mock_soln.interp_kernel_width,
+        real_t=mock_soln.real_t,
         mpi_construct=mpi_construct,
         ghost_size=ghost_size,
         interp_kernel_type=interp_kernel_type,
@@ -828,30 +680,16 @@ def test_mpi_interpolation_weights_kernel_on_nodes_2d(
     # For the reference local eul grid support, we compute using the previously tested
     # `local_eulerian_grid_support_of_lagrangian_grid_kernel(...)` kernel
     mask = np.where(rank_address == mpi_lagrangian_field_communicator.rank)[0]
-    mpi_local_lag_positions = ref_lag_positions[..., mask]
-    mpi_local_nearest_eul_grid_index_to_lag_grid = np.zeros(
-        (grid_dim, mpi_lagrangian_field_communicator.local_num_lag_nodes)
-    ).astype(int)
-    mpi_local_local_eul_grid_support_of_lag_grid = np.zeros(
-        (
-            grid_dim,
-            2 * interp_kernel_width,
-            2 * interp_kernel_width,
-            mpi_lagrangian_field_communicator.local_num_lag_nodes,
-        )
-    ).astype(real_t)
-    mpi_eul_lag_communicator.local_eulerian_grid_support_of_lagrangian_grid_kernel(
-        mpi_local_local_eul_grid_support_of_lag_grid,
-        mpi_local_nearest_eul_grid_index_to_lag_grid,
-        mpi_local_lag_positions,
+    mpi_local_local_eul_grid_support_of_lag_grid = (
+        mock_soln.mock_local_eul_grid_support_of_lag_grid
     )
     mpi_local_interp_weights = np.zeros(
         (
-            2 * interp_kernel_width,
-            2 * interp_kernel_width,
+            2 * mock_soln.interp_kernel_width,
+            2 * mock_soln.interp_kernel_width,
             mpi_lagrangian_field_communicator.local_num_lag_nodes,
         )
-    ).astype(real_t)
+    ).astype(mock_soln.real_t)
 
     # Test interpolation weights based on local eul grid support of lag grid
     mpi_eul_lag_communicator.interpolation_weights_kernel(
@@ -859,7 +697,7 @@ def test_mpi_interpolation_weights_kernel_on_nodes_2d(
         local_eul_grid_support_of_lag_grid=mpi_local_local_eul_grid_support_of_lag_grid,
     )
     np.testing.assert_allclose(
-        ref_interp_weights[..., mask],
+        mock_soln.interp_weights[..., mask],
         mpi_local_interp_weights,
         atol=get_test_tol(precision),
     )

--- a/tests/test_numeric/test_immersed_boundary_ops/test_eulerian_lagrangian_grid_communicator_mpi_2d.py
+++ b/tests/test_numeric/test_immersed_boundary_ops/test_eulerian_lagrangian_grid_communicator_mpi_2d.py
@@ -500,13 +500,10 @@ def test_mpi_lagrangian_to_eulerian_grid_interpolation_kernel_2d(
     )
 
     # Get corresponding local chunk of ref solution
+    local_grid_size_y, local_grid_size_x = mpi_construct.local_grid_size
     mpi_local_sol_idx = (
-        slice(
-            mpi_substart_idx[1], mpi_substart_idx[1] + mpi_construct.local_grid_size[0]
-        ),
-        slice(
-            mpi_substart_idx[0], mpi_substart_idx[0] + mpi_construct.local_grid_size[1]
-        ),
+        slice(mpi_substart_idx[1], mpi_substart_idx[1] + local_grid_size_y),
+        slice(mpi_substart_idx[0], mpi_substart_idx[0] + local_grid_size_x),
     )
 
     np.testing.assert_allclose(
@@ -599,15 +596,16 @@ def test_mpi_vector_field_lag_to_eul_grid_interpolation_kernel_2d(
     )
 
     # Get corresponding local chunk of ref solution
+    local_grid_size_y, local_grid_size_x = mpi_construct.local_grid_size
     mpi_local_sol_idx = (
         slice(None, None),
         slice(
             mpi_substart_idx[1],
-            mpi_substart_idx[1] + mpi_construct.local_grid_size[0],
+            mpi_substart_idx[1] + local_grid_size_y,
         ),
         slice(
             mpi_substart_idx[0],
-            mpi_substart_idx[0] + mpi_construct.local_grid_size[1],
+            mpi_substart_idx[0] + local_grid_size_x,
         ),
     )
 
@@ -618,7 +616,7 @@ def test_mpi_vector_field_lag_to_eul_grid_interpolation_kernel_2d(
     )
 
 
-@pytest.mark.mpi(group="MPI_immersed_boundary_ops_2d", min_size=8)
+@pytest.mark.mpi(group="MPI_immersed_boundary_ops_2d", min_size=4)
 @pytest.mark.parametrize("ghost_size", [1, 2, 3])
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("rank_distribution", [(1, 0), (0, 1)])
@@ -681,7 +679,7 @@ def test_mpi_interpolation_weights_kernel_on_nodes_2d(
     # `local_eulerian_grid_support_of_lagrangian_grid_kernel(...)` kernel
     mask = np.where(rank_address == mpi_lagrangian_field_communicator.rank)[0]
     mpi_local_local_eul_grid_support_of_lag_grid = (
-        mock_soln.mock_local_eul_grid_support_of_lag_grid
+        mock_soln.local_eul_grid_support_of_lag_grid[..., mask].copy()
     )
     mpi_local_interp_weights = np.zeros(
         (

--- a/tests/test_numeric/test_immersed_boundary_ops/test_eulerian_lagrangian_grid_communicator_mpi_2d.py
+++ b/tests/test_numeric/test_immersed_boundary_ops/test_eulerian_lagrangian_grid_communicator_mpi_2d.py
@@ -1,0 +1,865 @@
+import numpy as np
+import pytest
+from sopht_mpi.numeric.immersed_boundary_ops import (
+    EulerianLagrangianGridCommunicatorMPI2D,
+)
+from sopht.numeric.immersed_boundary_ops import EulerianLagrangianGridCommunicator2D
+from sopht_mpi.utils import (
+    MPIConstruct2D,
+    MPILagrangianFieldCommunicator2D,
+)
+from sopht.utils.precision import get_real_t, get_test_tol
+
+
+@pytest.mark.mpi(group="MPI_immersed_boundary_ops_2d", min_size=4)
+@pytest.mark.parametrize("ghost_size", [1, 2, 3])
+@pytest.mark.parametrize("precision", ["single", "double"])
+@pytest.mark.parametrize("rank_distribution", [(1, 0), (0, 1)])
+@pytest.mark.parametrize("aspect_ratio", [(1, 1), (1, 2), (2, 1)])
+def test_mpi_local_eulerian_grid_support_of_lagrangian_grid_2d(
+    ghost_size, precision, rank_distribution, aspect_ratio
+):
+    n_values = 32
+    real_t = get_real_t(precision)
+    grid_dim = 2
+    eul_grid_size_y = n_values * aspect_ratio[0]
+    eul_grid_size_x = n_values * aspect_ratio[1]
+    eul_grid_size = eul_grid_size_x
+    eul_domain_size = real_t(1.0)
+    eul_grid_dx = real_t(eul_domain_size / eul_grid_size)
+    eul_grid_coord_shift = real_t(0.5 * eul_grid_dx)
+    interp_kernel_width = 2
+    num_lag_nodes = 3
+
+    # 1. Generate reference solution from sopht-backend
+    eul_lag_communicator = EulerianLagrangianGridCommunicator2D(
+        dx=eul_grid_dx,
+        eul_grid_coord_shift=eul_grid_coord_shift,
+        num_lag_nodes=num_lag_nodes,
+        interp_kernel_width=interp_kernel_width,
+        real_t=real_t,
+    )
+    # init lag. grid around center of the domain
+    # this allows testing for the case where rank on first and last quarter (when there
+    # are 4 processes) does not contain any lagrangian nodes AND when the point lies at
+    # the boundary of MPI domain decomposition
+    ref_nearest_eul_grid_index_to_lag_grid = np.empty((grid_dim, num_lag_nodes)).astype(
+        int
+    )
+    ref_nearest_eul_grid_index_to_lag_grid[0] = np.arange(
+        eul_grid_size_x // 2 - 1, eul_grid_size_x // 2 - 1 + num_lag_nodes
+    ).astype(int)
+    ref_nearest_eul_grid_index_to_lag_grid[1] = np.arange(
+        eul_grid_size_y // 2 - 1, eul_grid_size_y // 2 - 1 + num_lag_nodes
+    ).astype(int)
+    ref_lag_positions = (
+        ref_nearest_eul_grid_index_to_lag_grid * eul_grid_dx + eul_grid_coord_shift
+    ).astype(real_t)
+
+    # find interpolation zone support for the lag. grid
+    ref_local_eul_grid_support_of_lag_grid = np.zeros(
+        (grid_dim, 2 * interp_kernel_width, 2 * interp_kernel_width, num_lag_nodes)
+    ).astype(real_t)
+    eul_lag_communicator.local_eulerian_grid_support_of_lagrangian_grid_kernel(
+        ref_local_eul_grid_support_of_lag_grid,
+        ref_nearest_eul_grid_index_to_lag_grid,
+        ref_lag_positions,
+    )
+
+    # 2. Initialize MPI related stuff
+    # Generate the MPI topology minimal object
+    mpi_construct = MPIConstruct2D(
+        grid_size_y=eul_grid_size_y,
+        grid_size_x=eul_grid_size_x,
+        real_t=real_t,
+        rank_distribution=rank_distribution,
+    )
+
+    # Lagrangian grid inter-rank MPI communicator
+    master_rank = 0
+    mpi_lagrangian_field_communicator = MPILagrangianFieldCommunicator2D(
+        eul_grid_dx=eul_grid_dx,
+        eul_grid_shift=eul_grid_coord_shift,
+        mpi_construct=mpi_construct,
+        master_rank=master_rank,
+        real_t=real_t,
+    )
+    # Map lagrangian nodes to ranks
+    mpi_lagrangian_field_communicator.map_lagrangian_nodes_based_on_position(
+        ref_lag_positions
+    )
+    rank_address = mpi_lagrangian_field_communicator.rank_address
+
+    # Initialize Eulerian-Lagrangian grid numerics communicator based on mpi local eul
+    # grid coord shift
+    mpi_eul_lag_communicator = EulerianLagrangianGridCommunicatorMPI2D(
+        dx=eul_grid_dx,
+        eul_grid_coord_shift=eul_grid_coord_shift,
+        interp_kernel_width=interp_kernel_width,
+        real_t=real_t,
+        mpi_construct=mpi_construct,
+        ghost_size=ghost_size,
+    )
+
+    # 3. Compute solution using MPI implementation
+    # since all the ranks have the same reference solution, we can just mask them out
+    # the "mpi rank local" data after mapping the lag nodes to their respective ranks
+    mask = np.where(rank_address == mpi_lagrangian_field_communicator.rank)[0]
+    mpi_local_lag_positions = ref_lag_positions[..., mask]
+    mpi_local_nearest_eul_grid_index_to_lag_grid = np.zeros(
+        (grid_dim, mpi_lagrangian_field_communicator.local_num_lag_nodes)
+    ).astype(int)
+    mpi_local_local_eul_grid_support_of_lag_grid = np.zeros(
+        (
+            grid_dim,
+            2 * interp_kernel_width,
+            2 * interp_kernel_width,
+            mpi_lagrangian_field_communicator.local_num_lag_nodes,
+        )
+    ).astype(real_t)
+
+    mpi_eul_lag_communicator.local_eulerian_grid_support_of_lagrangian_grid_kernel(
+        mpi_local_local_eul_grid_support_of_lag_grid,
+        mpi_local_nearest_eul_grid_index_to_lag_grid,
+        mpi_local_lag_positions,
+    )
+
+    # We need to shift the indices so that its based on the ref index frame and not the
+    # rank local index frame
+    mpi_substart_idx = mpi_eul_lag_communicator.mpi_substart_idx
+    mpi_local_nearest_eul_grid_index_to_lag_grid = (
+        mpi_local_nearest_eul_grid_index_to_lag_grid
+        - ghost_size
+        + mpi_substart_idx.reshape(grid_dim, 1)
+    ).astype(int)
+
+    # 4. Test and compare values
+    np.testing.assert_allclose(
+        ref_nearest_eul_grid_index_to_lag_grid[..., mask],
+        mpi_local_nearest_eul_grid_index_to_lag_grid,
+        atol=get_test_tol(precision),
+    )
+    np.testing.assert_allclose(
+        ref_local_eul_grid_support_of_lag_grid[..., mask],
+        mpi_local_local_eul_grid_support_of_lag_grid,
+        atol=get_test_tol(precision),
+    )
+
+
+@pytest.mark.mpi(group="MPI_immersed_boundary_ops_2d", min_size=4)
+@pytest.mark.parametrize("ghost_size", [pytest.param(1, marks=pytest.mark.xfail), 2, 3])
+@pytest.mark.parametrize("precision", ["single", "double"])
+@pytest.mark.parametrize("rank_distribution", [(1, 0), (0, 1)])
+@pytest.mark.parametrize("aspect_ratio", [(1, 1), (1, 2), (2, 1)])
+def test_mpi_eulerian_to_lagrangian_grid_interpolation_kernel_2d(
+    ghost_size, precision, rank_distribution, aspect_ratio
+):
+    n_values = 32
+    real_t = get_real_t(precision)
+    grid_dim = 2
+    eul_grid_size_y = n_values * aspect_ratio[0]
+    eul_grid_size_x = n_values * aspect_ratio[1]
+    eul_grid_size = eul_grid_size_x
+    eul_domain_size = real_t(1.0)
+    eul_grid_dx = real_t(eul_domain_size / eul_grid_size)
+    eul_grid_coord_shift = real_t(0.5 * eul_grid_dx)
+    interp_kernel_width = 2
+    num_lag_nodes = 3
+
+    # 1. Generate reference solution from sopht-backend
+    eul_lag_communicator = EulerianLagrangianGridCommunicator2D(
+        dx=eul_grid_dx,
+        eul_grid_coord_shift=eul_grid_coord_shift,
+        num_lag_nodes=num_lag_nodes,
+        interp_kernel_width=interp_kernel_width,
+        real_t=real_t,
+    )
+    eulerian_to_lagrangian_grid_interpolation_kernel = (
+        eul_lag_communicator.eulerian_to_lagrangian_grid_interpolation_kernel
+    )
+    # init lag. grid around center of the domain
+    # this allows testing for the case where rank on first and last quarter (when there
+    # are 4 processes) does not contain any lagrangian nodes AND when the point lies at
+    # the boundary of MPI domain decomposition
+    ref_nearest_eul_grid_index_to_lag_grid = np.empty((grid_dim, num_lag_nodes)).astype(
+        int
+    )
+    ref_nearest_eul_grid_index_to_lag_grid[0] = np.arange(
+        eul_grid_size_x // 2 - 1, eul_grid_size_x // 2 - 1 + num_lag_nodes
+    ).astype(int)
+    ref_nearest_eul_grid_index_to_lag_grid[1] = np.arange(
+        eul_grid_size_y // 2 - 1, eul_grid_size_y // 2 - 1 + num_lag_nodes
+    ).astype(int)
+    ref_lag_positions = (
+        ref_nearest_eul_grid_index_to_lag_grid * eul_grid_dx + eul_grid_coord_shift
+    ).astype(real_t)
+    # set interp weight as a series of 0 to 4 * interp_kernel_width ** 2 - 1
+    ref_interp_weights = np.arange(0, 4 * interp_kernel_width**2).reshape(
+        2 * interp_kernel_width, 2 * interp_kernel_width, 1
+    )
+    ref_interp_weights = np.tile(ref_interp_weights, reps=(1, 1, num_lag_nodes)).astype(
+        real_t
+    )
+    ref_lag_grid_field = np.zeros((num_lag_nodes), dtype=real_t)
+    ref_eul_grid_field = np.ones((eul_grid_size_y, eul_grid_size_x), dtype=real_t)
+    eulerian_to_lagrangian_grid_interpolation_kernel(
+        ref_lag_grid_field,
+        ref_eul_grid_field,
+        ref_interp_weights,
+        ref_nearest_eul_grid_index_to_lag_grid,
+    )
+
+    # 2. Initialize MPI related stuff
+    # Generate the MPI topology minimal object
+    mpi_construct = MPIConstruct2D(
+        grid_size_y=eul_grid_size_y,
+        grid_size_x=eul_grid_size_x,
+        real_t=real_t,
+        rank_distribution=rank_distribution,
+    )
+
+    # Lagrangian grid inter-rank MPI communicator
+    master_rank = 0
+    mpi_lagrangian_field_communicator = MPILagrangianFieldCommunicator2D(
+        eul_grid_dx=eul_grid_dx,
+        eul_grid_shift=eul_grid_coord_shift,
+        mpi_construct=mpi_construct,
+        master_rank=master_rank,
+        real_t=real_t,
+    )
+    # Map lagrangian nodes to ranks
+    mpi_lagrangian_field_communicator.map_lagrangian_nodes_based_on_position(
+        ref_lag_positions
+    )
+    rank_address = mpi_lagrangian_field_communicator.rank_address
+
+    # Initialize Eulerian-Lagrangian grid numerics communicator based on mpi local eul
+    # grid coord shift
+    mpi_eul_lag_communicator = EulerianLagrangianGridCommunicatorMPI2D(
+        dx=eul_grid_dx,
+        eul_grid_coord_shift=eul_grid_coord_shift,
+        interp_kernel_width=interp_kernel_width,
+        real_t=real_t,
+        mpi_construct=mpi_construct,
+        ghost_size=ghost_size,
+    )
+
+    # 3. Compute solution using MPI implementation
+    # since all the ranks have the same reference solution, we can just mask them out
+    # the "mpi rank local" data after mapping the lag nodes to their respective ranks
+    mask = np.where(rank_address == mpi_lagrangian_field_communicator.rank)[0]
+    mpi_local_eul_grid_field = np.ones(
+        mpi_construct.local_grid_size + 2 * ghost_size, dtype=real_t
+    )
+    mpi_local_interp_weights = ref_interp_weights[..., mask]
+    # indices needs to be offset with mpi local reference index
+    mpi_substart_idx = mpi_eul_lag_communicator.mpi_substart_idx
+    mpi_local_nearest_eul_grid_index_to_lag_grid = (
+        ref_nearest_eul_grid_index_to_lag_grid[..., mask]
+        + ghost_size
+        - mpi_substart_idx.reshape(grid_dim, 1)
+    )
+    mpi_local_lag_grid_field = np.zeros(
+        (mpi_lagrangian_field_communicator.local_num_lag_nodes), dtype=real_t
+    )
+    mpi_eul_lag_communicator.eulerian_to_lagrangian_grid_interpolation_kernel(
+        mpi_local_lag_grid_field,
+        mpi_local_eul_grid_field,
+        mpi_local_interp_weights,
+        mpi_local_nearest_eul_grid_index_to_lag_grid,
+    )
+
+    np.testing.assert_allclose(
+        ref_lag_grid_field[..., mask],
+        mpi_local_lag_grid_field,
+        atol=get_test_tol(precision),
+    )
+
+
+@pytest.mark.mpi(group="MPI_immersed_boundary_ops_2d", min_size=4)
+@pytest.mark.parametrize("ghost_size", [pytest.param(1, marks=pytest.mark.xfail), 2, 3])
+@pytest.mark.parametrize("precision", ["single", "double"])
+@pytest.mark.parametrize("rank_distribution", [(1, 0), (0, 1)])
+@pytest.mark.parametrize("aspect_ratio", [(1, 1), (1, 2), (2, 1)])
+def test_mpi_vector_field_eul_to_lag_grid_interpolation_kernel_2d(
+    ghost_size, precision, rank_distribution, aspect_ratio
+):
+    n_values = 32
+    real_t = get_real_t(precision)
+    grid_dim = 2
+    n_components = grid_dim
+    eul_grid_size_y = n_values * aspect_ratio[0]
+    eul_grid_size_x = n_values * aspect_ratio[1]
+    eul_grid_size = eul_grid_size_x
+    eul_domain_size = real_t(1.0)
+    eul_grid_dx = real_t(eul_domain_size / eul_grid_size)
+    eul_grid_coord_shift = real_t(0.5 * eul_grid_dx)
+    interp_kernel_width = 2
+    num_lag_nodes = 3
+
+    # 1. Generate reference solution from sopht-backend
+    eul_lag_communicator = EulerianLagrangianGridCommunicator2D(
+        dx=eul_grid_dx,
+        eul_grid_coord_shift=eul_grid_coord_shift,
+        num_lag_nodes=num_lag_nodes,
+        interp_kernel_width=interp_kernel_width,
+        n_components=2,
+        real_t=real_t,
+    )
+    eulerian_to_lagrangian_grid_interpolation_kernel = (
+        eul_lag_communicator.eulerian_to_lagrangian_grid_interpolation_kernel
+    )
+    # init lag. grid around center of the domain
+    # this allows testing for the case where rank on first and last quarter (when there
+    # are 4 processes) does not contain any lagrangian nodes AND when the point lies at
+    # the boundary of MPI domain decomposition
+    ref_nearest_eul_grid_index_to_lag_grid = np.empty((grid_dim, num_lag_nodes)).astype(
+        int
+    )
+    ref_nearest_eul_grid_index_to_lag_grid[0] = np.arange(
+        eul_grid_size_x // 2 - 1, eul_grid_size_x // 2 - 1 + num_lag_nodes
+    ).astype(int)
+    ref_nearest_eul_grid_index_to_lag_grid[1] = np.arange(
+        eul_grid_size_y // 2 - 1, eul_grid_size_y // 2 - 1 + num_lag_nodes
+    ).astype(int)
+    ref_lag_positions = (
+        ref_nearest_eul_grid_index_to_lag_grid * eul_grid_dx + eul_grid_coord_shift
+    ).astype(real_t)
+    # set interp weight as a series of 0 to 4 * interp_kernel_width ** 2 - 1
+    ref_interp_weights = np.arange(0, 4 * interp_kernel_width**2).reshape(
+        2 * interp_kernel_width, 2 * interp_kernel_width, 1
+    )
+    ref_interp_weights = np.tile(ref_interp_weights, reps=(1, 1, num_lag_nodes)).astype(
+        real_t
+    )
+    ref_lag_grid_field = np.zeros((n_components, num_lag_nodes), dtype=real_t)
+    ref_eul_grid_field = np.ones(
+        (n_components, eul_grid_size_y, eul_grid_size_x), dtype=real_t
+    )
+    eulerian_to_lagrangian_grid_interpolation_kernel(
+        ref_lag_grid_field,
+        ref_eul_grid_field,
+        ref_interp_weights,
+        ref_nearest_eul_grid_index_to_lag_grid,
+    )
+
+    # 2. Initialize MPI related stuff
+    # Generate the MPI topology minimal object
+    mpi_construct = MPIConstruct2D(
+        grid_size_y=eul_grid_size_y,
+        grid_size_x=eul_grid_size_x,
+        real_t=real_t,
+        rank_distribution=rank_distribution,
+    )
+
+    # Lagrangian grid inter-rank MPI communicator
+    master_rank = 0
+    mpi_lagrangian_field_communicator = MPILagrangianFieldCommunicator2D(
+        eul_grid_dx=eul_grid_dx,
+        eul_grid_shift=eul_grid_coord_shift,
+        mpi_construct=mpi_construct,
+        master_rank=master_rank,
+        real_t=real_t,
+    )
+    # Map lagrangian nodes to ranks
+    mpi_lagrangian_field_communicator.map_lagrangian_nodes_based_on_position(
+        ref_lag_positions
+    )
+    rank_address = mpi_lagrangian_field_communicator.rank_address
+
+    # Initialize Eulerian-Lagrangian grid numerics communicator based on mpi local eul
+    # grid coord shift
+    mpi_eul_lag_communicator = EulerianLagrangianGridCommunicatorMPI2D(
+        dx=eul_grid_dx,
+        eul_grid_coord_shift=eul_grid_coord_shift,
+        interp_kernel_width=interp_kernel_width,
+        n_components=2,
+        real_t=real_t,
+        mpi_construct=mpi_construct,
+        ghost_size=ghost_size,
+    )
+
+    # 3. Compute solution using MPI implementation
+    # since all the ranks have the same reference solution, we can just mask them out
+    # the "mpi rank local" data after mapping the lag nodes to their respective ranks
+    mask = np.where(rank_address == mpi_lagrangian_field_communicator.rank)[0]
+    mpi_local_eul_grid_field = np.ones(
+        (
+            n_components,
+            mpi_construct.local_grid_size[0] + 2 * ghost_size,
+            mpi_construct.local_grid_size[1] + 2 * ghost_size,
+        ),
+        dtype=real_t,
+    )
+    mpi_local_interp_weights = ref_interp_weights[..., mask]
+    # indices needs to be offset with mpi local reference index
+    mpi_substart_idx = mpi_eul_lag_communicator.mpi_substart_idx
+    mpi_local_nearest_eul_grid_index_to_lag_grid = (
+        ref_nearest_eul_grid_index_to_lag_grid[..., mask]
+        + ghost_size
+        - mpi_substart_idx.reshape(grid_dim, 1)
+    )
+    mpi_local_lag_grid_field = np.zeros(
+        (n_components, mpi_lagrangian_field_communicator.local_num_lag_nodes),
+        dtype=real_t,
+    )
+    mpi_eul_lag_communicator.eulerian_to_lagrangian_grid_interpolation_kernel(
+        mpi_local_lag_grid_field,
+        mpi_local_eul_grid_field,
+        mpi_local_interp_weights,
+        mpi_local_nearest_eul_grid_index_to_lag_grid,
+    )
+
+    np.testing.assert_allclose(
+        ref_lag_grid_field[..., mask],
+        mpi_local_lag_grid_field,
+        atol=get_test_tol(precision),
+    )
+
+
+@pytest.mark.mpi(group="MPI_immersed_boundary_ops_2d", min_size=4)
+@pytest.mark.parametrize("ghost_size", [pytest.param(1, marks=pytest.mark.xfail), 2, 3])
+@pytest.mark.parametrize("precision", ["single", "double"])
+@pytest.mark.parametrize("rank_distribution", [(1, 0), (0, 1)])
+@pytest.mark.parametrize("aspect_ratio", [(1, 1), (1, 2), (2, 1)])
+def test_mpi_lagrangian_to_eulerian_grid_interpolation_kernel_2d(
+    ghost_size,
+    precision,
+    rank_distribution,
+    aspect_ratio,
+):
+    n_values = 32
+    real_t = get_real_t(precision)
+    grid_dim = 2
+    eul_grid_size_y = n_values * aspect_ratio[0]
+    eul_grid_size_x = n_values * aspect_ratio[1]
+    eul_grid_size = eul_grid_size_x
+    eul_domain_size = real_t(1.0)
+    eul_grid_dx = real_t(eul_domain_size / eul_grid_size)
+    eul_grid_coord_shift = real_t(0.5 * eul_grid_dx)
+    interp_kernel_width = 2
+    num_lag_nodes = 3
+
+    # 1. Generate reference solution from sopht-backend
+    eul_lag_communicator = EulerianLagrangianGridCommunicator2D(
+        dx=eul_grid_dx,
+        eul_grid_coord_shift=eul_grid_coord_shift,
+        num_lag_nodes=num_lag_nodes,
+        interp_kernel_width=interp_kernel_width,
+        real_t=real_t,
+    )
+    lagrangian_to_eulerian_grid_interpolation_kernel = (
+        eul_lag_communicator.lagrangian_to_eulerian_grid_interpolation_kernel
+    )
+    # init lag. grid around center of the domain
+    # this allows testing for the case where rank on first and last quarter (when there
+    # are 4 processes) does not contain any lagrangian nodes AND when the points lie
+    # close to the boundary of MPI domain decomposition
+    ref_nearest_eul_grid_index_to_lag_grid = np.empty((grid_dim, num_lag_nodes)).astype(
+        int
+    )
+    ref_nearest_eul_grid_index_to_lag_grid[0] = np.arange(
+        eul_grid_size_x // 2 - 1, eul_grid_size_x // 2 - 1 + num_lag_nodes
+    ).astype(int)
+    ref_nearest_eul_grid_index_to_lag_grid[1] = np.arange(
+        eul_grid_size_y // 2 - 1, eul_grid_size_y // 2 - 1 + num_lag_nodes
+    ).astype(int)
+    # need ref lag positions to get rank address later
+    ref_lag_positions = (
+        ref_nearest_eul_grid_index_to_lag_grid * eul_grid_dx + eul_grid_coord_shift
+    ).astype(real_t)
+    # init interp weights as all ones, essentially this should lead to
+    # interpolation spreading ones onto the Eulerian grid
+    ref_interp_weights = np.ones(
+        (2 * interp_kernel_width, 2 * interp_kernel_width, num_lag_nodes),
+        dtype=real_t,
+    )
+    prefactor_lag_field = 2
+    ref_lag_grid_field = prefactor_lag_field * np.ones((num_lag_nodes), dtype=real_t)
+    ref_eul_grid_field = np.zeros((eul_grid_size_y, eul_grid_size_x), dtype=real_t)
+    lagrangian_to_eulerian_grid_interpolation_kernel(
+        ref_eul_grid_field,
+        ref_lag_grid_field,
+        ref_interp_weights,
+        ref_nearest_eul_grid_index_to_lag_grid,
+    )
+
+    # 2. Initialize MPI related stuff
+    # Generate the MPI topology minimal object
+    mpi_construct = MPIConstruct2D(
+        grid_size_y=eul_grid_size_y,
+        grid_size_x=eul_grid_size_x,
+        real_t=real_t,
+        rank_distribution=rank_distribution,
+    )
+
+    # Lagrangian grid inter-rank MPI communicator
+    master_rank = 0
+    mpi_lagrangian_field_communicator = MPILagrangianFieldCommunicator2D(
+        eul_grid_dx=eul_grid_dx,
+        eul_grid_shift=eul_grid_coord_shift,
+        mpi_construct=mpi_construct,
+        master_rank=master_rank,
+        real_t=real_t,
+    )
+    # Map lagrangian nodes to ranks
+    mpi_lagrangian_field_communicator.map_lagrangian_nodes_based_on_position(
+        ref_lag_positions
+    )
+    rank_address = mpi_lagrangian_field_communicator.rank_address
+
+    # Initialize Eulerian-Lagrangian grid numerics communicator based on mpi local eul
+    # grid coord shift
+    mpi_eul_lag_communicator = EulerianLagrangianGridCommunicatorMPI2D(
+        dx=eul_grid_dx,
+        eul_grid_coord_shift=eul_grid_coord_shift,
+        interp_kernel_width=interp_kernel_width,
+        real_t=real_t,
+        mpi_construct=mpi_construct,
+        ghost_size=ghost_size,
+    )
+
+    # 3. Compute solution using MPI implementation
+    # since all the ranks have the same reference solution, we can just mask them out
+    # the "mpi rank local" data after mapping the lag nodes to their respective ranks
+    mask = np.where(rank_address == mpi_lagrangian_field_communicator.rank)[0]
+    mpi_local_eul_grid_field = np.zeros(
+        mpi_construct.local_grid_size + 2 * ghost_size, dtype=real_t
+    )
+    mpi_local_lag_grid_field = ref_lag_grid_field[..., mask]
+    mpi_local_interp_weights = ref_interp_weights[..., mask]
+    # indices needs to be offset with mpi local reference index
+    mpi_substart_idx = mpi_eul_lag_communicator.mpi_substart_idx
+    mpi_local_nearest_eul_grid_index_to_lag_grid = (
+        ref_nearest_eul_grid_index_to_lag_grid[..., mask]
+        + ghost_size
+        - mpi_substart_idx.reshape(grid_dim, 1)
+    )
+
+    mpi_eul_lag_communicator.lagrangian_to_eulerian_grid_interpolation_kernel(
+        mpi_local_eul_grid_field,
+        mpi_local_lag_grid_field,
+        mpi_local_interp_weights,
+        mpi_local_nearest_eul_grid_index_to_lag_grid,
+    )
+
+    # Get corresponding local chunk of ref solution
+    mpi_local_sol_idx = (
+        slice(
+            mpi_substart_idx[1], mpi_substart_idx[1] + mpi_construct.local_grid_size[0]
+        ),
+        slice(
+            mpi_substart_idx[0], mpi_substart_idx[0] + mpi_construct.local_grid_size[1]
+        ),
+    )
+
+    np.testing.assert_allclose(
+        ref_eul_grid_field[mpi_local_sol_idx],
+        mpi_local_eul_grid_field[ghost_size:-ghost_size, ghost_size:-ghost_size],
+        atol=get_test_tol(precision),
+    )
+
+
+@pytest.mark.mpi(group="MPI_immersed_boundary_ops_2d", min_size=4)
+@pytest.mark.parametrize("ghost_size", [pytest.param(1, marks=pytest.mark.xfail), 2, 3])
+@pytest.mark.parametrize("precision", ["single", "double"])
+@pytest.mark.parametrize("rank_distribution", [(1, 0), (0, 1)])
+@pytest.mark.parametrize("aspect_ratio", [(1, 1), (1, 2), (2, 1)])
+def test_mpi_vector_field_lag_to_eul_grid_interpolation_kernel_2d(
+    ghost_size,
+    precision,
+    rank_distribution,
+    aspect_ratio,
+):
+    n_values = 32
+    real_t = get_real_t(precision)
+    grid_dim = 2
+    n_components = grid_dim
+    eul_grid_size_y = n_values * aspect_ratio[0]
+    eul_grid_size_x = n_values * aspect_ratio[1]
+    eul_grid_size = eul_grid_size_x
+    eul_domain_size = real_t(1.0)
+    eul_grid_dx = real_t(eul_domain_size / eul_grid_size)
+    eul_grid_coord_shift = real_t(0.5 * eul_grid_dx)
+    interp_kernel_width = 2
+    num_lag_nodes = 3
+
+    # 1. Generate reference solution from sopht-backend
+    eul_lag_communicator = EulerianLagrangianGridCommunicator2D(
+        dx=eul_grid_dx,
+        eul_grid_coord_shift=eul_grid_coord_shift,
+        num_lag_nodes=num_lag_nodes,
+        interp_kernel_width=interp_kernel_width,
+        real_t=real_t,
+        n_components=n_components,
+    )
+    lagrangian_to_eulerian_grid_interpolation_kernel = (
+        eul_lag_communicator.lagrangian_to_eulerian_grid_interpolation_kernel
+    )
+    # init lag. grid around center of the domain
+    # this allows testing for the case where rank on first and last quarter (when there
+    # are 4 processes) does not contain any lagrangian nodes AND when the point lies at
+    # the boundary of MPI domain decomposition
+    ref_nearest_eul_grid_index_to_lag_grid = np.empty((grid_dim, num_lag_nodes)).astype(
+        int
+    )
+    ref_nearest_eul_grid_index_to_lag_grid[0] = np.arange(
+        eul_grid_size_x // 2 - 1, eul_grid_size_x // 2 - 1 + num_lag_nodes
+    ).astype(int)
+    ref_nearest_eul_grid_index_to_lag_grid[1] = np.arange(
+        eul_grid_size_y // 2 - 1, eul_grid_size_y // 2 - 1 + num_lag_nodes
+    ).astype(int)
+    # need ref lag positions to get rank address later
+    ref_lag_positions = (
+        ref_nearest_eul_grid_index_to_lag_grid * eul_grid_dx + eul_grid_coord_shift
+    ).astype(real_t)
+    # init interp weights as all ones, essentially this should lead to
+    # interpolation spreading ones onto the Eulerian grid
+    ref_interp_weights = np.ones(
+        (2 * interp_kernel_width, 2 * interp_kernel_width, num_lag_nodes),
+        dtype=real_t,
+    )
+    prefactor_lag_field_y = 2
+    prefactor_lag_field_x = 3
+    ref_lag_grid_field = np.ones((n_components, num_lag_nodes), dtype=real_t)
+    ref_lag_grid_field[0] *= prefactor_lag_field_y
+    ref_lag_grid_field[1] *= prefactor_lag_field_x
+    ref_eul_grid_field = np.zeros(
+        (n_components, eul_grid_size_y, eul_grid_size_x), dtype=real_t
+    )
+    lagrangian_to_eulerian_grid_interpolation_kernel(
+        ref_eul_grid_field,
+        ref_lag_grid_field,
+        ref_interp_weights,
+        ref_nearest_eul_grid_index_to_lag_grid,
+    )
+
+    # 2. Initialize MPI related stuff
+    # Generate the MPI topology minimal object
+    mpi_construct = MPIConstruct2D(
+        grid_size_y=eul_grid_size_y,
+        grid_size_x=eul_grid_size_x,
+        real_t=real_t,
+        rank_distribution=rank_distribution,
+    )
+
+    # Lagrangian grid inter-rank MPI communicator
+    master_rank = 0
+    mpi_lagrangian_field_communicator = MPILagrangianFieldCommunicator2D(
+        eul_grid_dx=eul_grid_dx,
+        eul_grid_shift=eul_grid_coord_shift,
+        mpi_construct=mpi_construct,
+        master_rank=master_rank,
+        real_t=real_t,
+    )
+    # Map lagrangian nodes to ranks
+    mpi_lagrangian_field_communicator.map_lagrangian_nodes_based_on_position(
+        ref_lag_positions
+    )
+    rank_address = mpi_lagrangian_field_communicator.rank_address
+
+    # Initialize Eulerian-Lagrangian grid numerics communicator based on mpi local eul
+    # grid coord shift
+    mpi_eul_lag_communicator = EulerianLagrangianGridCommunicatorMPI2D(
+        dx=eul_grid_dx,
+        eul_grid_coord_shift=eul_grid_coord_shift,
+        interp_kernel_width=interp_kernel_width,
+        real_t=real_t,
+        mpi_construct=mpi_construct,
+        ghost_size=ghost_size,
+        n_components=n_components,
+    )
+
+    # 3. Compute solution using MPI implementation
+    # since all the ranks have the same reference solution, we can just mask them out
+    # the "mpi rank local" data after mapping the lag nodes to their respective ranks
+    mask = np.where(rank_address == mpi_lagrangian_field_communicator.rank)[0]
+    mpi_local_eul_grid_field = np.zeros(
+        (
+            2,
+            mpi_construct.local_grid_size[0] + 2 * ghost_size,
+            mpi_construct.local_grid_size[1] + 2 * ghost_size,
+        ),
+        dtype=real_t,
+    )
+    mpi_local_lag_grid_field = ref_lag_grid_field[..., mask]
+    mpi_local_interp_weights = ref_interp_weights[..., mask]
+    # indices needs to be offset with mpi local reference index
+    mpi_substart_idx = mpi_eul_lag_communicator.mpi_substart_idx
+    mpi_local_nearest_eul_grid_index_to_lag_grid = (
+        ref_nearest_eul_grid_index_to_lag_grid[..., mask]
+        + ghost_size
+        - mpi_substart_idx.reshape(grid_dim, 1)
+    )
+
+    mpi_eul_lag_communicator.lagrangian_to_eulerian_grid_interpolation_kernel(
+        mpi_local_eul_grid_field,
+        mpi_local_lag_grid_field,
+        mpi_local_interp_weights,
+        mpi_local_nearest_eul_grid_index_to_lag_grid,
+    )
+
+    # Get corresponding local chunk of ref solution
+    mpi_local_sol_idx = (
+        slice(None, None),
+        slice(
+            mpi_substart_idx[1],
+            mpi_substart_idx[1] + mpi_construct.local_grid_size[0],
+        ),
+        slice(
+            mpi_substart_idx[0],
+            mpi_substart_idx[0] + mpi_construct.local_grid_size[1],
+        ),
+    )
+
+    np.testing.assert_allclose(
+        ref_eul_grid_field[mpi_local_sol_idx],
+        mpi_local_eul_grid_field[:, ghost_size:-ghost_size, ghost_size:-ghost_size],
+        atol=get_test_tol(precision),
+    )
+
+
+@pytest.mark.mpi(group="MPI_immersed_boundary_ops_2d", min_size=4)
+@pytest.mark.parametrize("ghost_size", [1, 2, 3])
+@pytest.mark.parametrize("precision", ["single", "double"])
+@pytest.mark.parametrize("rank_distribution", [(1, 0), (0, 1)])
+@pytest.mark.parametrize("aspect_ratio", [(1, 1), (1, 2), (2, 1)])
+@pytest.mark.parametrize("interp_kernel_type", ["cosine", "peskin"])
+def test_mpi_interpolation_weights_kernel_on_nodes_2d(
+    ghost_size,
+    precision,
+    rank_distribution,
+    aspect_ratio,
+    interp_kernel_type,
+):
+    n_values = 32
+    real_t = get_real_t(precision)
+    grid_dim = 2
+    eul_grid_size_y = n_values * aspect_ratio[0]
+    eul_grid_size_x = n_values * aspect_ratio[1]
+    eul_grid_size = eul_grid_size_x
+    eul_domain_size = real_t(1.0)
+    eul_grid_dx = real_t(eul_domain_size / eul_grid_size)
+    eul_grid_coord_shift = real_t(0.5 * eul_grid_dx)
+    interp_kernel_width = 2
+    num_lag_nodes = 3
+
+    # 1. Generate reference solution from sopht-backend
+    eul_lag_communicator = EulerianLagrangianGridCommunicator2D(
+        dx=eul_grid_dx,
+        eul_grid_coord_shift=eul_grid_coord_shift,
+        num_lag_nodes=num_lag_nodes,
+        interp_kernel_width=interp_kernel_width,
+        real_t=real_t,
+        interp_kernel_type=interp_kernel_type,
+    )
+    interpolation_weights_kernel = eul_lag_communicator.interpolation_weights_kernel
+    # init lag. grid around center of the domain
+    # this allows testing for the case where rank on first and last quarter (when there
+    # are 4 processes) does not contain any lagrangian nodes AND when the point lies at
+    # the boundary of MPI domain decomposition
+    ref_nearest_eul_grid_index_to_lag_grid = np.empty((grid_dim, num_lag_nodes)).astype(
+        int
+    )
+    ref_nearest_eul_grid_index_to_lag_grid[0] = np.arange(
+        eul_grid_size_x // 2 - 1, eul_grid_size_x // 2 - 1 + num_lag_nodes
+    ).astype(int)
+    ref_nearest_eul_grid_index_to_lag_grid[1] = np.arange(
+        eul_grid_size_y // 2 - 1, eul_grid_size_y // 2 - 1 + num_lag_nodes
+    ).astype(int)
+    ref_lag_positions = (
+        ref_nearest_eul_grid_index_to_lag_grid * eul_grid_dx + eul_grid_coord_shift
+    ).astype(real_t)
+    # find interpolation zone support for the lag. grid
+    ref_local_eul_grid_support_of_lag_grid = np.zeros(
+        (grid_dim, 2 * interp_kernel_width, 2 * interp_kernel_width, num_lag_nodes)
+    ).astype(real_t)
+    eul_lag_communicator.local_eulerian_grid_support_of_lagrangian_grid_kernel(
+        ref_local_eul_grid_support_of_lag_grid,
+        ref_nearest_eul_grid_index_to_lag_grid,
+        ref_lag_positions,
+    )
+    # compute reference interpolation weights
+    ref_interp_weights = np.zeros(
+        (2 * interp_kernel_width, 2 * interp_kernel_width, num_lag_nodes),
+        dtype=real_t,
+    )
+    interpolation_weights_kernel(
+        ref_interp_weights, ref_local_eul_grid_support_of_lag_grid
+    )
+
+    # 2. Initialize MPI related stuff
+    # Generate the MPI topology minimal object
+    mpi_construct = MPIConstruct2D(
+        grid_size_y=eul_grid_size_y,
+        grid_size_x=eul_grid_size_x,
+        real_t=real_t,
+        rank_distribution=rank_distribution,
+    )
+
+    # Lagrangian grid inter-rank MPI communicator
+    master_rank = 0
+    mpi_lagrangian_field_communicator = MPILagrangianFieldCommunicator2D(
+        eul_grid_dx=eul_grid_dx,
+        eul_grid_shift=eul_grid_coord_shift,
+        mpi_construct=mpi_construct,
+        master_rank=master_rank,
+        real_t=real_t,
+    )
+    # Map lagrangian nodes to ranks
+    mpi_lagrangian_field_communicator.map_lagrangian_nodes_based_on_position(
+        ref_lag_positions
+    )
+    rank_address = mpi_lagrangian_field_communicator.rank_address
+
+    # Initialize Eulerian-Lagrangian grid numerics communicator based on mpi local eul
+    # grid coord shift
+    mpi_eul_lag_communicator = EulerianLagrangianGridCommunicatorMPI2D(
+        dx=eul_grid_dx,
+        eul_grid_coord_shift=eul_grid_coord_shift,
+        interp_kernel_width=interp_kernel_width,
+        real_t=real_t,
+        mpi_construct=mpi_construct,
+        ghost_size=ghost_size,
+        interp_kernel_type=interp_kernel_type,
+    )
+
+    # 3. Compute solution using MPI implementation
+    # For the reference local eul grid support, we compute using the previously tested
+    # `local_eulerian_grid_support_of_lagrangian_grid_kernel(...)` kernel
+    mask = np.where(rank_address == mpi_lagrangian_field_communicator.rank)[0]
+    mpi_local_lag_positions = ref_lag_positions[..., mask]
+    mpi_local_nearest_eul_grid_index_to_lag_grid = np.zeros(
+        (grid_dim, mpi_lagrangian_field_communicator.local_num_lag_nodes)
+    ).astype(int)
+    mpi_local_local_eul_grid_support_of_lag_grid = np.zeros(
+        (
+            grid_dim,
+            2 * interp_kernel_width,
+            2 * interp_kernel_width,
+            mpi_lagrangian_field_communicator.local_num_lag_nodes,
+        )
+    ).astype(real_t)
+    mpi_eul_lag_communicator.local_eulerian_grid_support_of_lagrangian_grid_kernel(
+        mpi_local_local_eul_grid_support_of_lag_grid,
+        mpi_local_nearest_eul_grid_index_to_lag_grid,
+        mpi_local_lag_positions,
+    )
+    mpi_local_interp_weights = np.zeros(
+        (
+            2 * interp_kernel_width,
+            2 * interp_kernel_width,
+            mpi_lagrangian_field_communicator.local_num_lag_nodes,
+        )
+    ).astype(real_t)
+
+    # Test interpolation weights based on local eul grid support of lag grid
+    mpi_eul_lag_communicator.interpolation_weights_kernel(
+        interp_weights=mpi_local_interp_weights,
+        local_eul_grid_support_of_lag_grid=mpi_local_local_eul_grid_support_of_lag_grid,
+    )
+    np.testing.assert_allclose(
+        ref_interp_weights[..., mask],
+        mpi_local_interp_weights,
+        atol=get_test_tol(precision),
+    )

--- a/tests/test_numeric/test_immersed_boundary_ops/test_eulerian_lagrangian_grid_communicator_mpi_2d.py
+++ b/tests/test_numeric/test_immersed_boundary_ops/test_eulerian_lagrangian_grid_communicator_mpi_2d.py
@@ -184,7 +184,7 @@ def test_mpi_local_eulerian_grid_support_of_lagrangian_grid_2d(
     master_rank = 0
     mpi_lagrangian_field_communicator = MPILagrangianFieldCommunicator2D(
         eul_grid_dx=mock_soln.eul_grid_dx,
-        eul_grid_shift=mock_soln.eul_grid_coord_shift,
+        eul_grid_coord_shift=mock_soln.eul_grid_coord_shift,
         mpi_construct=mpi_construct,
         master_rank=master_rank,
         real_t=mock_soln.real_t,
@@ -278,7 +278,7 @@ def test_mpi_eulerian_to_lagrangian_grid_interpolation_kernel_2d(
     master_rank = 0
     mpi_lagrangian_field_communicator = MPILagrangianFieldCommunicator2D(
         eul_grid_dx=mock_soln.eul_grid_dx,
-        eul_grid_shift=mock_soln.eul_grid_coord_shift,
+        eul_grid_coord_shift=mock_soln.eul_grid_coord_shift,
         mpi_construct=mpi_construct,
         master_rank=master_rank,
         real_t=mock_soln.real_t,
@@ -360,7 +360,7 @@ def test_mpi_vector_field_eul_to_lag_grid_interpolation_kernel_2d(
     master_rank = 0
     mpi_lagrangian_field_communicator = MPILagrangianFieldCommunicator2D(
         eul_grid_dx=mock_soln.eul_grid_dx,
-        eul_grid_shift=mock_soln.eul_grid_coord_shift,
+        eul_grid_coord_shift=mock_soln.eul_grid_coord_shift,
         mpi_construct=mpi_construct,
         master_rank=master_rank,
         real_t=mock_soln.real_t,
@@ -453,7 +453,7 @@ def test_mpi_lagrangian_to_eulerian_grid_interpolation_kernel_2d(
     master_rank = 0
     mpi_lagrangian_field_communicator = MPILagrangianFieldCommunicator2D(
         eul_grid_dx=mock_soln.eul_grid_dx,
-        eul_grid_shift=mock_soln.eul_grid_coord_shift,
+        eul_grid_coord_shift=mock_soln.eul_grid_coord_shift,
         mpi_construct=mpi_construct,
         master_rank=master_rank,
         real_t=mock_soln.real_t,
@@ -543,7 +543,7 @@ def test_mpi_vector_field_lag_to_eul_grid_interpolation_kernel_2d(
     master_rank = 0
     mpi_lagrangian_field_communicator = MPILagrangianFieldCommunicator2D(
         eul_grid_dx=mock_soln.eul_grid_dx,
-        eul_grid_shift=mock_soln.eul_grid_coord_shift,
+        eul_grid_coord_shift=mock_soln.eul_grid_coord_shift,
         mpi_construct=mpi_construct,
         master_rank=master_rank,
         real_t=mock_soln.real_t,
@@ -651,7 +651,7 @@ def test_mpi_interpolation_weights_kernel_on_nodes_2d(
     master_rank = 0
     mpi_lagrangian_field_communicator = MPILagrangianFieldCommunicator2D(
         eul_grid_dx=mock_soln.eul_grid_dx,
-        eul_grid_shift=mock_soln.eul_grid_coord_shift,
+        eul_grid_coord_shift=mock_soln.eul_grid_coord_shift,
         mpi_construct=mpi_construct,
         master_rank=master_rank,
         real_t=mock_soln.real_t,


### PR DESCRIPTION
Fixes #58 

@bhosale2 this is a bit more involved, and the test case might seem a bit lengthy but once you get how they are tested from one of the test cases, it will be easier to review since they all follow the same style, just testing for different things. Thanks!

#### **Some additional notes to hopefully help with the review process:**
_The idea here is we scatter the lag grid quantities to their corresponding ranks depending on the lag node positions (this is taken care of by `MPILagrangianFieldCommunicator()`), and each of the ranks will then run the eul-lag grid communication independently. In the case where ranks do not contain any lag nodes, they automatically do a no-op, and so they are not affected. While the lag node communication between ranks is done explicitly here for testing, the scattering and gathering of these quantities will be internalised later in `VirtualBoundaryForcing()` class as found in PR #68 ._