### PR TITLE
Internalize get max vorticity in flow simulator

### DIFF
--- a/examples/2d_examples/LambOseenVortexCase/lamb_oseen_vortex.py
+++ b/examples/2d_examples/LambOseenVortexCase/lamb_oseen_vortex.py
@@ -91,9 +91,8 @@ def lamb_oseen_vortex_flow_case(
             mpi_plotter.savefig(file_name="snap_" + str("%0.4d" % (t * 100)) + ".png")
             mpi_plotter.clearfig()
 
+            max_vort = flow_sim.get_max_vorticity()
             # TODO: (logger) refactor later
-            max_vort_local = np.amax(flow_sim.vorticity_field)
-            max_vort = flow_sim.mpi_construct.grid.allreduce(max_vort_local, op=MPI.MAX)
             if flow_sim.mpi_construct.rank == 0:
                 print(
                     f"time: {t:.2f} ({((t-t_start)/(t_end-t_start)*100):2.1f}%), "

--- a/sopht_mpi/sopht_mpi_simulator/flow/flow_simulators_mpi_2d.py
+++ b/sopht_mpi/sopht_mpi_simulator/flow/flow_simulators_mpi_2d.py
@@ -295,11 +295,15 @@ class UnboundedFlowSimulator2D:
                 )
                 + get_test_tol(precision)
             ),
-            0.9
-            * self.dx**2
-            / (2 * self.grid_dim)
-            / (self.kinematic_viscosity + get_test_tol(precision)),
+            0.9 * self.dx**2 / (2 * self.grid_dim) / (self.kinematic_viscosity),
         )
         # Get smallest timestep among all the ranks
         dt = self.mpi_construct.grid.allreduce(dt, op=MPI.MIN)
         return dt * dt_prefac
+
+    def get_max_vorticity(self):
+        """Compute maximum vorticity"""
+        gs = self.ghost_size
+        max_vort_local = np.amax(self.vorticity_field[gs:-gs, gs:-gs])
+        max_vort = self.mpi_construct.grid.allreduce(max_vort_local, op=MPI.MAX)
+        return max_vort


### PR DESCRIPTION
Fixes #70 . Also removed the addition of precision when computing stable timestep in diffusion time step limit (consistent with sopht-examples).