### PR TITLE
Flow forces for elastica simulator

### DIFF
--- a/sopht_mpi/sopht_mpi_simulator/immersed_body/__init__.py
+++ b/sopht_mpi/sopht_mpi_simulator/immersed_body/__init__.py
@@ -2,3 +2,4 @@ from sopht_mpi.sopht_mpi_simulator.immersed_body.immersed_body_flow_interaction_
 from sopht_mpi.sopht_mpi_simulator.immersed_body.immersed_body_forcing_grid import *
 from sopht_mpi.sopht_mpi_simulator.immersed_body.rigid_body import *
 from sopht_mpi.sopht_mpi_simulator.immersed_body.cosserat_rod import *
+from sopht_mpi.sopht_mpi_simulator.immersed_body.flow_forces import *

--- a/sopht_mpi/sopht_mpi_simulator/immersed_body/flow_forces.py
+++ b/sopht_mpi/sopht_mpi_simulator/immersed_body/flow_forces.py
@@ -1,0 +1,16 @@
+from sopht_mpi.sopht_mpi_simulator.immersed_body import ImmersedBodyFlowInteractionMPI
+from elastica import CosseratRod, NoForces, RigidBodyBase
+from typing import Union
+
+
+class FlowForces(NoForces):
+    def __init__(self, body_flow_interactor: type(ImmersedBodyFlowInteractionMPI)):
+        super(NoForces, self).__init__()
+        self.body_flow_interactor = body_flow_interactor
+
+    def apply_forces(
+        self, system: Union[type(CosseratRod), type(RigidBodyBase)], time=0.0
+    ):
+        self.body_flow_interactor.compute_flow_forces_and_torques()
+        system.external_forces += self.body_flow_interactor.body_flow_forces
+        system.external_torques += self.body_flow_interactor.body_flow_torques

--- a/tests/test_simulator/immersed_body/test_flow_forces.py
+++ b/tests/test_simulator/immersed_body/test_flow_forces.py
@@ -1,0 +1,32 @@
+import numpy as np
+import sopht_mpi.sopht_mpi_simulator as sps
+
+
+class MockBodyFlowInteractor:
+    def __init__(self):
+        self.body_flow_forces = 0.0
+        self.body_flow_torques = 0.0
+
+    def compute_flow_forces_and_torques(self):
+        self.body_flow_forces = 1.0
+        self.body_flow_torques = 2.0
+
+
+class MockRod:
+    def __init__(self):
+        self.external_forces = 3.0
+        self.external_torques = 4.0
+
+
+def test_flow_forces():
+    body_flow_interactor = MockBodyFlowInteractor()
+    flow_forcing = sps.FlowForces(body_flow_interactor=body_flow_interactor)
+    assert body_flow_interactor is flow_forcing.body_flow_interactor
+
+    rod = MockRod()
+    flow_forcing.apply_forces(system=rod)
+    # check mock systems for values below
+    correct_external_forces = 1.0 + 3.0
+    correct_external_torques = 2.0 + 4.0
+    np.testing.assert_allclose(correct_external_forces, rod.external_forces)
+    np.testing.assert_allclose(correct_external_torques, rod.external_torques)


### PR DESCRIPTION
Fixes #75 

Since the `FlowForces` are only relevant on the master rank (i.e. rank with global lagrangian quantities), we can use the code from `sopht-examples` as is, just like the forcing grid classes. With this PR merged, we should have all the ingredients required for running the flow past rod case. I will be pushing the results and comparisons for that case over the weekend.