### PR TITLE
Flow past rod example case

### DIFF
--- a/examples/2d_examples/FlowPastRodCase/flow_past_rod.py
+++ b/examples/2d_examples/FlowPastRodCase/flow_past_rod.py
@@ -1,0 +1,281 @@
+import elastica as ea
+import matplotlib.pyplot as plt
+import numpy as np
+import os
+from sopht.utils.precision import get_real_t
+import sopht_mpi.sopht_mpi_simulator as sps
+from sopht_mpi.utils.mpi_utils_2d import MPIPlotter2D
+
+
+def flow_past_rod_case(
+    non_dim_final_time,
+    grid_size_x,
+    grid_size_y,
+    reynolds=200.0,
+    nondim_bending_stiffness=1.5e-3,
+    nondim_mass_ratio=1.5,
+    froude=0.5,
+    rod_start_incline_angle=0.0,
+    coupling_stiffness=-8e4,
+    coupling_damping=-30,
+    rank_distribution=None,
+    precision="single",
+):
+    # =================COMMON SIMULATOR STUFF=======================
+    velocity_free_stream = 1.0
+    rho_f = 1.0
+    base_length = 1.0
+    x_range = 6.0 * base_length
+    y_range = grid_size_y / grid_size_x * x_range
+    # =================PYELASTICA STUFF BEGIN=====================
+    class FlowPastRodSimulator(
+        ea.BaseSystemCollection, ea.Constraints, ea.Forcing, ea.Damping
+    ):
+        pass
+
+    flow_past_sim = FlowPastRodSimulator()
+    # setting up test params
+    n_elem = grid_size_x // 8
+    start = np.array([base_length, 0.501 * y_range, 0.0])
+    direction = np.array(
+        [np.cos(rod_start_incline_angle), np.sin(rod_start_incline_angle), 0.0]
+    )
+    normal = np.array([0.0, 0.0, 1.0])
+    base_radius = 0.01
+    base_area = np.pi * base_radius**2
+    z_axis_width = 1.0
+    # nondim_mass_ratio = rod_line_density / (rho_f * base_length * z_axis_width)
+    rod_line_density = nondim_mass_ratio * rho_f * base_length * z_axis_width
+    density = rod_line_density / base_area
+    moment_of_inertia = np.pi / 4 * base_radius**4
+    # nondim_bending_stiffness = youngs_modulus * moment_of_inertia
+    # / (rho_f vel_free_stream^2 base_length^3)
+    youngs_modulus = (
+        nondim_bending_stiffness
+        * (rho_f * velocity_free_stream**2 * base_length**3 * z_axis_width)
+        / moment_of_inertia
+    )
+    poisson_ratio = 0.5
+    # Fr = gravitational_acc * base_length / velocity_free_stream ^ 2
+    gravitational_acc = froude * velocity_free_stream**2 / base_length
+
+    flow_past_rod = ea.CosseratRod.straight_rod(
+        n_elem,
+        start,
+        direction,
+        normal,
+        base_length,
+        base_radius,
+        density,
+        0.0,  # internal damping constant, deprecated in v0.3.0
+        youngs_modulus,
+        shear_modulus=youngs_modulus / (poisson_ratio + 1.0),
+    )
+    tip_start_position = flow_past_rod.position_collection[:2, -1]
+    flow_past_sim.append(flow_past_rod)
+    flow_past_sim.constrain(flow_past_rod).using(
+        ea.OneEndFixedBC, constrained_position_idx=(0,), constrained_director_idx=(0,)
+    )
+    # Add gravitational forces
+    flow_past_sim.add_forcing_to(flow_past_rod).using(
+        ea.GravityForces, acc_gravity=np.array([gravitational_acc, 0.0, 0.0])
+    )
+    # add damping
+    dl = base_length / n_elem
+    rod_dt = 0.01 * dl
+    damping_constant = 0.5e-3
+    flow_past_sim.dampen(flow_past_rod).using(
+        ea.AnalyticalLinearDamper,
+        damping_constant=damping_constant,
+        time_step=rod_dt,
+    )
+    # =================PYELASTICA STUFF END=====================
+
+    # ==================FLOW SETUP START=========================
+    flow_solver_precision = precision
+    real_t = get_real_t(flow_solver_precision)
+    # Flow parameters
+    # Re = velocity_free_stream * base_length / nu
+    nu = base_length * velocity_free_stream / reynolds
+    flow_sim = sps.UnboundedFlowSimulator2D(
+        grid_size=(grid_size_y, grid_size_x),
+        x_range=x_range,
+        kinematic_viscosity=nu,
+        flow_type="navier_stokes_with_forcing",
+        with_free_stream_flow=True,
+        real_t=real_t,
+        rank_distribution=rank_distribution,
+    )
+    # ==================FLOW SETUP END=========================
+
+    # ==================FLOW-ROD COMMUNICATOR SETUP START======
+    master_rank = 0
+    cosserat_rod_flow_interactor = sps.CosseratRodFlowInteraction(
+        mpi_construct=flow_sim.mpi_construct,
+        mpi_ghost_exchange_communicator=flow_sim.mpi_ghost_exchange_communicator,
+        cosserat_rod=flow_past_rod,
+        eul_grid_forcing_field=flow_sim.eul_grid_forcing_field,
+        eul_grid_velocity_field=flow_sim.velocity_field,
+        virtual_boundary_stiffness_coeff=coupling_stiffness,
+        virtual_boundary_damping_coeff=coupling_damping,
+        dx=flow_sim.dx,
+        grid_dim=2,
+        real_t=real_t,
+        forcing_grid_cls=sps.CosseratRodElementCentricForcingGrid,
+        master_rank=master_rank,
+    )
+    flow_past_sim.add_forcing_to(flow_past_rod).using(
+        sps.FlowForces,
+        cosserat_rod_flow_interactor,
+    )
+    # ==================FLOW-ROD COMMUNICATOR SETUP END======
+
+    # =================TIMESTEPPING====================
+
+    flow_past_sim.finalize()
+    timestepper = ea.PositionVerlet()
+    do_step, stages_and_updates = ea.extend_stepper_interface(
+        timestepper, flow_past_sim
+    )
+    time = 0.0
+    foto_timer = 0.0
+    timescale = base_length / velocity_free_stream
+    final_time = non_dim_final_time * timescale
+    foto_timer_limit = final_time / 60
+
+    # setup freestream ramping
+    ramp_timescale = timescale
+    velocity_free_stream_perturb = 0.5 * velocity_free_stream
+
+    data_timer = 0.0
+    data_timer_limit = 0.1 * timescale
+    tip_time = []
+    tip_position = []
+
+    # Initialize field plotter
+    mpi_plotter = MPIPlotter2D(
+        flow_sim.mpi_construct,
+        flow_sim.ghost_size,
+    )
+
+    while time < final_time:
+
+        # Plot solution
+        if foto_timer >= foto_timer_limit or foto_timer == 0:
+            foto_timer = 0.0
+            mpi_plotter.ax.set_title(f"Vorticity, time: {time / timescale:.2f}")
+            mpi_plotter.contourf(
+                flow_sim.x_grid,
+                flow_sim.y_grid,
+                flow_sim.vorticity_field,
+                levels=np.linspace(-5, 5, 100),
+                extend="both",
+            )
+            mpi_plotter.plot(
+                cosserat_rod_flow_interactor.forcing_grid.position_field[0],
+                cosserat_rod_flow_interactor.forcing_grid.position_field[1],
+                linewidth=3,
+                color="k",
+            )
+            mpi_plotter.savefig(
+                file_name="snap_" + str("%0.4d" % (time * 100)) + ".png"
+            )
+            mpi_plotter.clearfig()
+
+            # Compute some diagnostics to log
+            grid_dev_error_l2_norm = (
+                cosserat_rod_flow_interactor.get_grid_deviation_error_l2_norm()
+            )
+            max_vort = flow_sim.get_max_vorticity()
+            # TODO: replace with logger when available
+            if flow_sim.mpi_construct.rank == master_rank:
+                print(
+                    f"time: {time:.2f} ({(time / final_time*100):2.1f}%), "
+                    f"max_vort: {max_vort:.4f}, "
+                    f"grid deviation L2 error: {grid_dev_error_l2_norm:.8f}"
+                )
+
+        # save diagnostic data
+        if (data_timer >= data_timer_limit or data_timer == 0):
+            data_timer = 0.0
+            if flow_sim.mpi_construct.rank == master_rank:
+                tip_time.append(time / timescale)
+                tip_position.append(
+                    (flow_past_rod.position_collection[:2, -1] - tip_start_position) / base_length
+                )
+
+        # compute timestep
+        flow_dt = flow_sim.compute_stable_timestep(dt_prefac=0.5)
+
+        # timestep the rod, through the flow timestep
+        rod_time_steps = int(flow_dt / min(flow_dt, rod_dt))
+        local_rod_dt = flow_dt / rod_time_steps
+        rod_time = time
+        for i in range(rod_time_steps):
+            rod_time = do_step(
+                timestepper, stages_and_updates, flow_past_sim, rod_time, local_rod_dt
+            )
+            # timestep the cosserat_rod_flow_interactor
+            cosserat_rod_flow_interactor.time_step(dt=local_rod_dt)
+
+        # evaluate feedback/interaction between flow and rod
+        cosserat_rod_flow_interactor()
+
+        ramp_factor = np.exp(-time / ramp_timescale)
+        # timestep the flow
+        flow_sim.time_step(
+            dt=flow_dt,
+            free_stream_velocity=[
+                velocity_free_stream * (1.0 - ramp_factor),
+                velocity_free_stream_perturb * ramp_factor,
+            ],
+        )
+
+        # update simulation time
+        time += flow_dt
+        foto_timer += flow_dt
+        data_timer += flow_dt
+
+    # compile video and other diagnostics plots
+    if flow_sim.mpi_construct.rank == master_rank:
+        os.system("rm -f flow.mp4")
+        os.system(
+            "ffmpeg -r 10 -s 3840x2160 -f image2 -pattern_type glob -i 'snap*.png' "
+            "-vcodec libx264 -crf 15 -pix_fmt yuv420p -vf 'crop=trunc(iw/2)*2:trunc(ih/2)*2'"
+            " flow.mp4"
+        )
+        os.system("rm -f snap*.png")
+
+        np.savetxt(
+            fname="rod_diagnostics_vs_time.csv",
+            X=np.c_[
+                np.array(tip_time),
+                np.array(tip_position)[..., 0],
+                np.array(tip_position)[..., 1],
+            ],
+            header="time, tip_x, tip_y",
+            delimiter=",",
+        )
+
+        # Plot tip position
+        mpi_plotter.ax.set_aspect(aspect="auto")
+        mpi_plotter.ax.set_title("Rod tip deflection")
+        mpi_plotter.plot(np.array(tip_time), np.array(tip_position)[..., 0], label="X")
+        mpi_plotter.plot(np.array(tip_time), np.array(tip_position)[..., 1], label="Y")
+        mpi_plotter.ax.legend()
+        mpi_plotter.ax.set_xlabel("Non-dimensional time")
+        mpi_plotter.ax.set_ylabel("Tip deflection")
+        mpi_plotter.savefig("tip_position_vs_time.png")
+        mpi_plotter.clearfig()
+
+
+
+if __name__ == "__main__":
+    grid_size_x = 256
+    grid_size_y = grid_size_x // 2
+    flow_past_rod_case(
+        non_dim_final_time=75.0,
+        grid_size_x=grid_size_x,
+        grid_size_y=grid_size_y,
+        precision="double",
+    )


### PR DESCRIPTION
Fixes #69 

Please find the comparisons between `sopht-examples` and `sopht-mpi` for the flow past rod example case.
The case is ran with the same default settings in `sopht-examples` found [here](https://github.com/SophT-Team/SophT-Examples/blob/main/examples/2d_examples/FlowPastRodCase/flow_past_rod.py).

**Discussion:** The elastica simulator is initialized on all ranks, but _**only**_ the master rank is given the full lagrangian grid forcing (i.e. flow information). For now, I kept the simulators running on all the ranks since other ranks have to wait for the master rank to finish computing the rod dynamics anyway. It doesn't seem like we urgently need to necessarily make elastica run only on the master rank, unless perhaps we know that the rods will never come in contact with each other apriori, then it might be beneficial to parallelize the elastica computations by initializing each rod to a simulator and assigning them to different ranks (any thoughts on this?). In any case, I have yet to figure out a clean way to enable elastica rank assignment feature (i.e. without invoking if-else statements here and there in the example case files). Please let me know what you think, I think I might need some second opinion and perhaps suggestions here @bhosale2 

### Sopht-examples
https://user-images.githubusercontent.com/12764958/201495338-98e1e0bc-aeca-4dbd-be27-3a0ec440e108.mp4

### Sopht-mpi
https://user-images.githubusercontent.com/12764958/201495346-01b7d914-38d1-4b37-ba4f-c34de119ed6a.mp4

### Rod diagnostics comparisons
<img width="1310" alt="image" src="https://user-images.githubusercontent.com/12764958/201495387-b4bc4483-15fd-4bca-b60d-0b71cd7e9fa9.png">

<img width="1315" alt="image" src="https://user-images.githubusercontent.com/12764958/201495407-e36e36ed-4924-46df-a1ff-b99d366c3a0b.png">
