### PR TITLE
Make mpi 3d utils consistent with mpi 2d utils

### DIFF
--- a/tests/test_utils/test_mpi_utils_2d.py
+++ b/tests/test_utils/test_mpi_utils_2d.py
@@ -72,7 +72,6 @@ def test_mpi_ghost_communication(
         rank_distribution=rank_distribution,
     )
     # extra width needed for kernel computation
-    ghost_size = 1
     mpi_ghost_exchange_communicator = MPIGhostCommunicator2D(
         ghost_size=ghost_size, mpi_construct=mpi_construct
     )


### PR DESCRIPTION
Fixes #93 . Minor changes to MPI 3D utils.

There are only Eulerian MPI 3D utils so far, will implement the Lagrangian ones when we get to developing immersed body kernels.