### PR TITLE
Refactor ghost comm for scalar and vector field

### DIFF
--- a/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_2d/advection_flux_mpi_2d.py
+++ b/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_2d/advection_flux_mpi_2d.py
@@ -32,9 +32,8 @@ def gen_advection_flux_conservative_eno3_pyst_mpi_kernel_2d(
         # define variable for use later
         ghost_size = ghost_exchange_communicator.ghost_size
         # begin ghost comm.
-        ghost_exchange_communicator.exchange_init(field, mpi_construct)
-        ghost_exchange_communicator.exchange_init(velocity[0], mpi_construct)
-        ghost_exchange_communicator.exchange_init(velocity[1], mpi_construct)
+        ghost_exchange_communicator.exchange_scalar_field_init(field)
+        ghost_exchange_communicator.exchange_vector_field_init(velocity)
 
         # crunch interior stencil
         advection_flux_pyst_kernel(

--- a/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_2d/diffusion_flux_mpi_2d.py
+++ b/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_2d/diffusion_flux_mpi_2d.py
@@ -42,7 +42,7 @@ def gen_diffusion_flux_pyst_mpi_kernel_2d(
         # define variable for use later
         ghost_size = ghost_exchange_communicator.ghost_size
         # begin ghost comm.
-        ghost_exchange_communicator.exchange_init(field, mpi_construct)
+        ghost_exchange_communicator.exchange_scalar_field_init(field)
 
         # crunch interior stencil
         diffusion_flux_pyst_kernel(

--- a/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_2d/outplane_field_curl_mpi_2d.py
+++ b/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_2d/outplane_field_curl_mpi_2d.py
@@ -44,7 +44,7 @@ def gen_outplane_field_curl_pyst_mpi_kernel_2d(
         # define variable for use later
         ghost_size = ghost_exchange_communicator.ghost_size
         # begin ghost comm.
-        ghost_exchange_communicator.exchange_init(field, mpi_construct)
+        ghost_exchange_communicator.exchange_scalar_field_init(field)
 
         # crunch interior stencil
         outplane_field_curl_pyst_kernel_2d(

--- a/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_2d/update_vorticity_from_velocity_forcing_mpi_2d.py
+++ b/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_2d/update_vorticity_from_velocity_forcing_mpi_2d.py
@@ -40,12 +40,7 @@ def gen_update_vorticity_from_velocity_forcing_pyst_mpi_kernel_2d(
         # define variable for use later
         ghost_size = ghost_exchange_communicator.ghost_size
         # begin ghost comm.
-        ghost_exchange_communicator.exchange_init(
-            velocity_forcing_field[0], mpi_construct
-        )
-        ghost_exchange_communicator.exchange_init(
-            velocity_forcing_field[1], mpi_construct
-        )
+        ghost_exchange_communicator.exchange_vector_field_init(velocity_forcing_field)
 
         # crunch interior stencil
         update_vorticity_from_velocity_forcing_pyst_kernel_2d(

--- a/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_3d/advection_flux_mpi_3d.py
+++ b/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_3d/advection_flux_mpi_3d.py
@@ -32,10 +32,8 @@ def gen_advection_flux_conservative_eno3_pyst_mpi_kernel_3d(
         # define variable for use later
         ghost_size = ghost_exchange_communicator.ghost_size
         # begin ghost comm.
-        ghost_exchange_communicator.exchange_init(field, mpi_construct)
-        ghost_exchange_communicator.exchange_init(velocity[0], mpi_construct)
-        ghost_exchange_communicator.exchange_init(velocity[1], mpi_construct)
-        ghost_exchange_communicator.exchange_init(velocity[2], mpi_construct)
+        ghost_exchange_communicator.exchange_scalar_field_init(field)
+        ghost_exchange_communicator.exchange_vector_field_init(velocity)
 
         # crunch interior stencil
         advection_flux_pyst_kernel(

--- a/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_3d/curl_mpi_3d.py
+++ b/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_3d/curl_mpi_3d.py
@@ -38,7 +38,7 @@ def gen_curl_pyst_mpi_kernel_3d(real_t, mpi_construct, ghost_exchange_communicat
         # define variable for use later
         ghost_size = ghost_exchange_communicator.ghost_size
         # begin ghost comm.
-        ghost_exchange_communicator.exchange_init(field, mpi_construct)
+        ghost_exchange_communicator.exchange_scalar_field_init(field)
 
         # crunch interior stencil
         curl_pyst_kernel_3d(

--- a/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_3d/diffusion_flux_mpi_3d.py
+++ b/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_3d/diffusion_flux_mpi_3d.py
@@ -44,7 +44,7 @@ def gen_diffusion_flux_pyst_mpi_kernel_3d(
         # define variable for use later
         ghost_size = ghost_exchange_communicator.ghost_size
         # begin ghost comm.
-        ghost_exchange_communicator.exchange_init(field, mpi_construct)
+        ghost_exchange_communicator.exchange_scalar_field_init(field)
 
         # crunch interior stencil
         diffusion_flux_pyst_kernel(

--- a/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_3d/divergence_mpi_3d.py
+++ b/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_3d/divergence_mpi_3d.py
@@ -41,9 +41,7 @@ def gen_divergence_pyst_mpi_kernel_3d(
         # define variable for use later
         ghost_size = ghost_exchange_communicator.ghost_size
         # begin ghost comm.
-        ghost_exchange_communicator.exchange_init(field[0], mpi_construct)
-        ghost_exchange_communicator.exchange_init(field[1], mpi_construct)
-        ghost_exchange_communicator.exchange_init(field[2], mpi_construct)
+        ghost_exchange_communicator.exchange_vector_field_init(field)
 
         # crunch interior stencil
         divergence_pyst_kernel(

--- a/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_3d/update_vorticity_from_velocity_forcing_mpi_3d.py
+++ b/sopht_mpi/numeric/eulerian_grid_ops/stencil_ops_3d/update_vorticity_from_velocity_forcing_mpi_3d.py
@@ -43,15 +43,7 @@ def gen_update_vorticity_from_velocity_forcing_pyst_mpi_kernel_3d(
         ghost_size = ghost_exchange_communicator.ghost_size
         # begin ghost comm.
         # TODO: replace with vector field exchange
-        ghost_exchange_communicator.exchange_init(
-            velocity_forcing_field[0], mpi_construct
-        )
-        ghost_exchange_communicator.exchange_init(
-            velocity_forcing_field[1], mpi_construct
-        )
-        ghost_exchange_communicator.exchange_init(
-            velocity_forcing_field[2], mpi_construct
-        )
+        ghost_exchange_communicator.exchange_vector_field_init(velocity_forcing_field)
 
         # crunch interior stencil
         update_vorticity_from_velocity_forcing_pyst_kernel_3d(
@@ -223,18 +215,8 @@ def gen_update_vorticity_from_penalised_velocity_pyst_mpi_kernel_3d(
         ghost_size = ghost_exchange_communicator.ghost_size
         # begin ghost comm.
         # TODO: replace with vector field exchange
-        ghost_exchange_communicator.exchange_init(velocity_field[0], mpi_construct)
-        ghost_exchange_communicator.exchange_init(velocity_field[1], mpi_construct)
-        ghost_exchange_communicator.exchange_init(velocity_field[2], mpi_construct)
-        ghost_exchange_communicator.exchange_init(
-            penalised_velocity_field[0], mpi_construct
-        )
-        ghost_exchange_communicator.exchange_init(
-            penalised_velocity_field[1], mpi_construct
-        )
-        ghost_exchange_communicator.exchange_init(
-            penalised_velocity_field[2], mpi_construct
-        )
+        ghost_exchange_communicator.exchange_vector_field_init(velocity_field)
+        ghost_exchange_communicator.exchange_vector_field_init(penalised_velocity_field)
 
         # crunch interior stencil
         update_vorticity_from_penalised_velocity_pyst_kernel_3d(

--- a/sopht_mpi/simulator/immersed_body/immersed_body_flow_interaction_mpi.py
+++ b/sopht_mpi/simulator/immersed_body/immersed_body_flow_interaction_mpi.py
@@ -110,11 +110,8 @@ class ImmersedBodyFlowInteractionMPI(VirtualBoundaryForcingMPI):
         self.forcing_grid.compute_lag_grid_velocity_field()
         # 2. Ghost the velocity field
         self.eul_grid_velocity_field.flags.writeable = True
-        self.mpi_ghost_exchange_communicator.exchange_init(
-            self.eul_grid_velocity_field[0], self.mpi_construct
-        )
-        self.mpi_ghost_exchange_communicator.exchange_init(
-            self.eul_grid_velocity_field[1], self.mpi_construct
+        self.mpi_ghost_exchange_communicator.exchange_vector_field_init(
+            self.eul_grid_velocity_field
         )
         self.mpi_ghost_exchange_communicator.exchange_finalise()
         self.eul_grid_velocity_field.flags.writeable = False
@@ -132,11 +129,8 @@ class ImmersedBodyFlowInteractionMPI(VirtualBoundaryForcingMPI):
         self.forcing_grid.compute_lag_grid_velocity_field()
         # 2. Ghost the velocity field
         self.eul_grid_velocity_field.flags.writeable = True
-        self.mpi_ghost_exchange_communicator.exchange_init(
-            self.eul_grid_velocity_field[0], self.mpi_construct
-        )
-        self.mpi_ghost_exchange_communicator.exchange_init(
-            self.eul_grid_velocity_field[1], self.mpi_construct
+        self.mpi_ghost_exchange_communicator.exchange_vector_field_init(
+            self.eul_grid_velocity_field
         )
         self.mpi_ghost_exchange_communicator.exchange_finalise()
         self.eul_grid_velocity_field.flags.writeable = False

--- a/sopht_mpi/utils/mpi_utils_2d.py
+++ b/sopht_mpi/utils/mpi_utils_2d.py
@@ -3,6 +3,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 from sopht_mpi.utils.lab_cmap import lab_cmap
 from sopht_mpi.utils.mpi_logger import logger
+from sopht.utils.field import VectorField
 
 
 class MPIConstruct2D:
@@ -214,8 +215,12 @@ class MPIGhostCommunicator2D:
         )
 
     def exchange_vector_field_init(self, local_vector_field):
-        self.exchange_scalar_field_init(local_field=local_vector_field[0])
-        self.exchange_scalar_field_init(local_field=local_vector_field[1])
+        self.exchange_scalar_field_init(
+            local_field=local_vector_field[VectorField.x_axis_idx()]
+        )
+        self.exchange_scalar_field_init(
+            local_field=local_vector_field[VectorField.y_axis_idx()]
+        )
 
     def exchange_finalise(self):
         """

--- a/sopht_mpi/utils/mpi_utils_2d.py
+++ b/sopht_mpi/utils/mpi_utils_2d.py
@@ -97,6 +97,7 @@ class MPIGhostCommunicator2D:
                 "for calling ghost communication."
             )
         self.ghost_size = ghost_size
+        self.mpi_construct = mpi_construct
         # define field_size variable for local field size (which includes ghost)
         self.field_size = mpi_construct.local_grid_size + 2 * self.ghost_size
 
@@ -114,99 +115,115 @@ class MPIGhostCommunicator2D:
         )
         self.column_type.Commit()
 
-        # non-blocking comm, stuff
-        self.num_requests = (
-            mpi_construct.grid_dim * 2 * 2
-        )  # dimension * 2 request for send/recv * 2 directions along each axis
-        # Initialize the requests array?
-        self.comm_requests = [
-            0,
-        ] * self.num_requests
+        # Initialize requests list for non-blocking comm
+        self.comm_requests = []
 
-    def exchange_init(self, local_field, mpi_construct):
+    def exchange_scalar_field_init(self, local_field):
         """
-        Exchange ghost data between neighbors.
+        Exchange scalar field ghost data between neighbors.
         """
         # Lines below to make code more literal
         y_axis = 0
         x_axis = 1
         # Along Y: send to previous block, receive from next block
-        self.comm_requests[0] = mpi_construct.grid.Isend(
-            (
-                local_field[self.ghost_size : 2 * self.ghost_size, :],
-                1,
-                self.row_type,
-            ),
-            dest=mpi_construct.previous_grid_along[y_axis],
+        self.comm_requests.append(
+            self.mpi_construct.grid.Isend(
+                (
+                    local_field[self.ghost_size : 2 * self.ghost_size, :],
+                    1,
+                    self.row_type,
+                ),
+                dest=self.mpi_construct.previous_grid_along[y_axis],
+            )
         )
-        self.comm_requests[1] = mpi_construct.grid.Irecv(
-            (
-                local_field[-self.ghost_size : local_field.shape[0], :],
-                1,
-                self.row_type,
-            ),
-            source=mpi_construct.next_grid_along[y_axis],
+        self.comm_requests.append(
+            self.mpi_construct.grid.Irecv(
+                (
+                    local_field[-self.ghost_size : local_field.shape[0], :],
+                    1,
+                    self.row_type,
+                ),
+                source=self.mpi_construct.next_grid_along[y_axis],
+            )
         )
 
         # Along Y: send to next block, receive from previous block
-        self.comm_requests[2] = mpi_construct.grid.Isend(
-            (
-                local_field[-2 * self.ghost_size : -self.ghost_size, :],
-                1,
-                self.row_type,
-            ),
-            dest=mpi_construct.next_grid_along[y_axis],
+        self.comm_requests.append(
+            self.mpi_construct.grid.Isend(
+                (
+                    local_field[-2 * self.ghost_size : -self.ghost_size, :],
+                    1,
+                    self.row_type,
+                ),
+                dest=self.mpi_construct.next_grid_along[y_axis],
+            )
         )
-        self.comm_requests[3] = mpi_construct.grid.Irecv(
-            (
-                local_field[0 : self.ghost_size, :],
-                1,
-                self.row_type,
-            ),
-            source=mpi_construct.previous_grid_along[y_axis],
+        self.comm_requests.append(
+            self.mpi_construct.grid.Irecv(
+                (
+                    local_field[0 : self.ghost_size, :],
+                    1,
+                    self.row_type,
+                ),
+                source=self.mpi_construct.previous_grid_along[y_axis],
+            )
         )
 
         # Along X: send to previous block, receive from next block
-        self.comm_requests[4] = mpi_construct.grid.Isend(
-            (
-                local_field.ravel()[self.ghost_size :],
-                1,
-                self.column_type,
-            ),
-            dest=mpi_construct.previous_grid_along[x_axis],
+        self.comm_requests.append(
+            self.mpi_construct.grid.Isend(
+                (
+                    local_field.ravel()[self.ghost_size :],
+                    1,
+                    self.column_type,
+                ),
+                dest=self.mpi_construct.previous_grid_along[x_axis],
+            )
         )
-        self.comm_requests[5] = mpi_construct.grid.Irecv(
-            (
-                local_field.ravel()[local_field.shape[1] - self.ghost_size :],
-                1,
-                self.column_type,
-            ),
-            source=mpi_construct.next_grid_along[x_axis],
+        self.comm_requests.append(
+            self.mpi_construct.grid.Irecv(
+                (
+                    local_field.ravel()[local_field.shape[1] - self.ghost_size :],
+                    1,
+                    self.column_type,
+                ),
+                source=self.mpi_construct.next_grid_along[x_axis],
+            )
         )
 
         # Along X: send to next block, receive from previous block
-        self.comm_requests[6] = mpi_construct.grid.Isend(
-            (
-                local_field.ravel()[local_field.shape[1] - 2 * self.ghost_size :],
-                1,
-                self.column_type,
-            ),
-            dest=mpi_construct.next_grid_along[x_axis],
+        self.comm_requests.append(
+            self.mpi_construct.grid.Isend(
+                (
+                    local_field.ravel()[local_field.shape[1] - 2 * self.ghost_size :],
+                    1,
+                    self.column_type,
+                ),
+                dest=self.mpi_construct.next_grid_along[x_axis],
+            )
         )
-        self.comm_requests[7] = mpi_construct.grid.Irecv(
-            (
-                local_field.ravel()[0:],
-                1,
-                self.column_type,
-            ),
-            source=mpi_construct.previous_grid_along[x_axis],
+        self.comm_requests.append(
+            self.mpi_construct.grid.Irecv(
+                (
+                    local_field.ravel()[0:],
+                    1,
+                    self.column_type,
+                ),
+                source=self.mpi_construct.previous_grid_along[x_axis],
+            )
         )
+
+    def exchange_vector_field_init(self, local_vector_field):
+        self.exchange_scalar_field_init(local_field=local_vector_field[0])
+        self.exchange_scalar_field_init(local_field=local_vector_field[1])
 
     def exchange_finalise(self):
         """
         Finalizing non-blocking exchange ghost data between neighbors.
         """
         MPI.Request.Waitall(self.comm_requests)
+        # reset the list of requests
+        self.comm_requests = []
 
 
 class MPIFieldCommunicator2D:

--- a/sopht_mpi/utils/mpi_utils_3d.py
+++ b/sopht_mpi/utils/mpi_utils_3d.py
@@ -1,6 +1,7 @@
 from mpi4py import MPI
 import numpy as np
 from sopht_mpi.utils.mpi_logger import logger
+from sopht.utils.field import VectorField
 
 
 class MPIConstruct3D:
@@ -281,9 +282,15 @@ class MPIGhostCommunicator3D:
         )
 
     def exchange_vector_field_init(self, local_vector_field):
-        self.exchange_scalar_field_init(local_field=local_vector_field[0])
-        self.exchange_scalar_field_init(local_field=local_vector_field[1])
-        self.exchange_scalar_field_init(local_field=local_vector_field[2])
+        self.exchange_scalar_field_init(
+            local_field=local_vector_field[VectorField.x_axis_idx()]
+        )
+        self.exchange_scalar_field_init(
+            local_field=local_vector_field[VectorField.y_axis_idx()]
+        )
+        self.exchange_scalar_field_init(
+            local_field=local_vector_field[VectorField.z_axis_idx()]
+        )
 
     def exchange_finalise(self):
         """

--- a/tests/test_numeric/test_immersed_boundary_ops/test_virtual_boundary_forcing_mpi_2d.py
+++ b/tests/test_numeric/test_immersed_boundary_ops/test_virtual_boundary_forcing_mpi_2d.py
@@ -685,12 +685,8 @@ def test_mpi_compute_interaction_force_on_lag_grid_2d(
         mpi_construct,
     )
     # ghost the local field
-    mpi_ghost_exchange_communicator.exchange_init(
-        mpi_local_eul_grid_velocity_field[0], mpi_construct
-    )
-    mpi_ghost_exchange_communicator.exchange_finalise()
-    mpi_ghost_exchange_communicator.exchange_init(
-        mpi_local_eul_grid_velocity_field[1], mpi_construct
+    mpi_ghost_exchange_communicator.exchange_vector_field_init(
+        mpi_local_eul_grid_velocity_field
     )
     mpi_ghost_exchange_communicator.exchange_finalise()
 
@@ -873,12 +869,8 @@ def test_mpi_compute_interaction_force_on_eul_and_lag_grid_2d(
         mpi_construct,
     )
     # ghost the local field
-    mpi_ghost_exchange_communicator.exchange_init(
-        mpi_local_eul_grid_velocity_field[0], mpi_construct
-    )
-    mpi_ghost_exchange_communicator.exchange_finalise()
-    mpi_ghost_exchange_communicator.exchange_init(
-        mpi_local_eul_grid_velocity_field[1], mpi_construct
+    mpi_ghost_exchange_communicator.exchange_vector_field_init(
+        mpi_local_eul_grid_velocity_field
     )
     mpi_ghost_exchange_communicator.exchange_finalise()
 

--- a/tests/test_simulator/immersed_body/test_immersed_body_interaction_mpi.py
+++ b/tests/test_simulator/immersed_body/test_immersed_body_interaction_mpi.py
@@ -113,11 +113,8 @@ def test_mpi_immersed_body_interactor_call_method(master_rank, precision):
     forcing_grid.compute_lag_grid_position_field()
     forcing_grid.compute_lag_grid_velocity_field()
     # 2. Ghost the velocity field
-    cylinder_flow_interactor.mpi_ghost_exchange_communicator.exchange_init(
-        local_eul_grid_velocity_field[0], cylinder_flow_interactor.mpi_construct
-    )
-    cylinder_flow_interactor.mpi_ghost_exchange_communicator.exchange_init(
-        local_eul_grid_velocity_field[1], cylinder_flow_interactor.mpi_construct
+    cylinder_flow_interactor.mpi_ghost_exchange_communicator.exchange_vector_field_init(
+        local_eul_grid_velocity_field
     )
     cylinder_flow_interactor.mpi_ghost_exchange_communicator.exchange_finalise()
     # 3. Compute interaction forcing
@@ -155,11 +152,8 @@ def test_mpi_immersed_body_interactor_compute_flow_forces_and_torques(
     forcing_grid.compute_lag_grid_position_field()
     forcing_grid.compute_lag_grid_velocity_field()
     # 2. Ghost the velocity field
-    cylinder_flow_interactor.mpi_ghost_exchange_communicator.exchange_init(
-        local_eul_grid_velocity_field[0], cylinder_flow_interactor.mpi_construct
-    )
-    cylinder_flow_interactor.mpi_ghost_exchange_communicator.exchange_init(
-        local_eul_grid_velocity_field[1], cylinder_flow_interactor.mpi_construct
+    cylinder_flow_interactor.mpi_ghost_exchange_communicator.exchange_vector_field_init(
+        local_eul_grid_velocity_field
     )
     cylinder_flow_interactor.mpi_ghost_exchange_communicator.exchange_finalise()
     # 3. Compute interaction forcing on lag grid

--- a/tests/test_utils/test_mpi_utils_2d.py
+++ b/tests/test_utils/test_mpi_utils_2d.py
@@ -77,31 +77,63 @@ def test_mpi_ghost_communication(
     )
     # Set internal field to manufactured values
     np.random.seed(0)
-    local_field = np.random.rand(
+    local_scalar_field = np.random.rand(
+        mpi_construct.local_grid_size[0] + 2 * ghost_size,
+        mpi_construct.local_grid_size[1] + 2 * ghost_size,
+    ).astype(real_t)
+    local_vector_field = np.random.rand(
+        mpi_construct.grid_dim,
         mpi_construct.local_grid_size[0] + 2 * ghost_size,
         mpi_construct.local_grid_size[1] + 2 * ghost_size,
     ).astype(real_t)
 
     # ghost comm.
-    mpi_ghost_exchange_communicator.exchange_init(local_field, mpi_construct)
+    mpi_ghost_exchange_communicator.exchange_scalar_field_init(local_scalar_field)
+    mpi_ghost_exchange_communicator.exchange_vector_field_init(local_vector_field)
     mpi_ghost_exchange_communicator.exchange_finalise()
 
     # check if comm. done rightly!
+    # Test scalar field
     np.testing.assert_allclose(
-        local_field[ghost_size : 2 * ghost_size, ghost_size:-ghost_size],
-        local_field[-ghost_size : local_field.shape[0], ghost_size:-ghost_size],
+        local_scalar_field[ghost_size : 2 * ghost_size, ghost_size:-ghost_size],
+        local_scalar_field[
+            -ghost_size : local_scalar_field.shape[0], ghost_size:-ghost_size
+        ],
     )
     np.testing.assert_allclose(
-        local_field[-2 * ghost_size : -ghost_size, ghost_size:-ghost_size],
-        local_field[0:ghost_size, ghost_size:-ghost_size],
+        local_scalar_field[-2 * ghost_size : -ghost_size, ghost_size:-ghost_size],
+        local_scalar_field[0:ghost_size, ghost_size:-ghost_size],
     )
     np.testing.assert_allclose(
-        local_field[ghost_size:-ghost_size, ghost_size : 2 * ghost_size],
-        local_field[ghost_size:-ghost_size, -ghost_size : local_field.shape[1]],
+        local_scalar_field[ghost_size:-ghost_size, ghost_size : 2 * ghost_size],
+        local_scalar_field[
+            ghost_size:-ghost_size, -ghost_size : local_scalar_field.shape[1]
+        ],
     )
     np.testing.assert_allclose(
-        local_field[ghost_size:-ghost_size, -2 * ghost_size : -ghost_size],
-        local_field[ghost_size:-ghost_size, 0:ghost_size],
+        local_scalar_field[ghost_size:-ghost_size, -2 * ghost_size : -ghost_size],
+        local_scalar_field[ghost_size:-ghost_size, 0:ghost_size],
+    )
+    # Test vector field
+    np.testing.assert_allclose(
+        local_vector_field[:, ghost_size : 2 * ghost_size, ghost_size:-ghost_size],
+        local_vector_field[
+            :, -ghost_size : local_vector_field.shape[1], ghost_size:-ghost_size
+        ],
+    )
+    np.testing.assert_allclose(
+        local_vector_field[:, -2 * ghost_size : -ghost_size, ghost_size:-ghost_size],
+        local_vector_field[:, 0:ghost_size, ghost_size:-ghost_size],
+    )
+    np.testing.assert_allclose(
+        local_vector_field[:, ghost_size:-ghost_size, ghost_size : 2 * ghost_size],
+        local_vector_field[
+            :, ghost_size:-ghost_size, -ghost_size : local_vector_field.shape[2]
+        ],
+    )
+    np.testing.assert_allclose(
+        local_vector_field[:, ghost_size:-ghost_size, -2 * ghost_size : -ghost_size],
+        local_vector_field[:, ghost_size:-ghost_size, 0:ghost_size],
     )
 
 

--- a/tests/test_utils/test_mpi_utils_3d.py
+++ b/tests/test_utils/test_mpi_utils_3d.py
@@ -94,74 +94,171 @@ def test_mpi_ghost_communication(
     )
     # Set internal field to manufactured values
     np.random.seed(0)
-    local_field = np.random.rand(
+    local_scalar_field = np.random.rand(
+        mpi_construct.local_grid_size[0] + 2 * ghost_size,
+        mpi_construct.local_grid_size[1] + 2 * ghost_size,
+        mpi_construct.local_grid_size[2] + 2 * ghost_size,
+    ).astype(real_t)
+    local_vector_field = np.random.rand(
+        mpi_construct.grid_dim,
         mpi_construct.local_grid_size[0] + 2 * ghost_size,
         mpi_construct.local_grid_size[1] + 2 * ghost_size,
         mpi_construct.local_grid_size[2] + 2 * ghost_size,
     ).astype(real_t)
 
     # ghost comm.
-    mpi_ghost_exchange_communicator.exchange_init(local_field, mpi_construct)
+    mpi_ghost_exchange_communicator.exchange_scalar_field_init(local_scalar_field)
+    mpi_ghost_exchange_communicator.exchange_vector_field_init(local_vector_field)
     mpi_ghost_exchange_communicator.exchange_finalise()
 
     # check if comm. done rightly!
+    # Test scalar field
     # Along X: comm with previous block
     np.testing.assert_allclose(
-        local_field[
+        local_scalar_field[
             ghost_size:-ghost_size, ghost_size:-ghost_size, ghost_size : 2 * ghost_size
         ],
-        local_field[
+        local_scalar_field[
             ghost_size:-ghost_size,
             ghost_size:-ghost_size,
-            -ghost_size : local_field.shape[2],
+            -ghost_size : local_scalar_field.shape[2],
         ],
     )
     # Along X: comm with next block
     np.testing.assert_allclose(
-        local_field[
+        local_scalar_field[
             ghost_size:-ghost_size,
             ghost_size:-ghost_size,
             -2 * ghost_size : -ghost_size,
         ],
-        local_field[ghost_size:-ghost_size, ghost_size:-ghost_size, 0:ghost_size],
+        local_scalar_field[
+            ghost_size:-ghost_size, ghost_size:-ghost_size, 0:ghost_size
+        ],
     )
     # Along Y: comm with previous block
     np.testing.assert_allclose(
-        local_field[
+        local_scalar_field[
             ghost_size:-ghost_size, ghost_size : 2 * ghost_size, ghost_size:-ghost_size
         ],
-        local_field[
+        local_scalar_field[
             ghost_size:-ghost_size,
-            -ghost_size : local_field.shape[1],
+            -ghost_size : local_scalar_field.shape[1],
             ghost_size:-ghost_size,
         ],
     )
     # Along Y: comm with next block
     np.testing.assert_allclose(
-        local_field[
+        local_scalar_field[
             ghost_size:-ghost_size,
             -2 * ghost_size : -ghost_size,
             ghost_size:-ghost_size,
         ],
-        local_field[ghost_size:-ghost_size, 0:ghost_size, ghost_size:-ghost_size],
+        local_scalar_field[
+            ghost_size:-ghost_size, 0:ghost_size, ghost_size:-ghost_size
+        ],
     )
     # Along Z: comm with previous block
     np.testing.assert_allclose(
-        local_field[
+        local_scalar_field[
             ghost_size : 2 * ghost_size, ghost_size:-ghost_size, ghost_size:-ghost_size
         ],
-        local_field[
-            -ghost_size : local_field.shape[0],
+        local_scalar_field[
+            -ghost_size : local_scalar_field.shape[0],
             ghost_size:-ghost_size,
             ghost_size:-ghost_size,
         ],
     )
     # Along Z: comm with next block
     np.testing.assert_allclose(
-        local_field[
+        local_scalar_field[
             -2 * ghost_size : -ghost_size,
             ghost_size:-ghost_size,
             ghost_size:-ghost_size,
         ],
-        local_field[0:ghost_size, ghost_size:-ghost_size, ghost_size:-ghost_size],
+        local_scalar_field[
+            0:ghost_size, ghost_size:-ghost_size, ghost_size:-ghost_size
+        ],
+    )
+
+    # Test vector field
+    # Along X: comm with previous block
+    np.testing.assert_allclose(
+        local_vector_field[
+            :,
+            ghost_size:-ghost_size,
+            ghost_size:-ghost_size,
+            ghost_size : 2 * ghost_size,
+        ],
+        local_vector_field[
+            :,
+            ghost_size:-ghost_size,
+            ghost_size:-ghost_size,
+            -ghost_size : local_vector_field.shape[3],
+        ],
+    )
+    # Along X: comm with next block
+    np.testing.assert_allclose(
+        local_vector_field[
+            :,
+            ghost_size:-ghost_size,
+            ghost_size:-ghost_size,
+            -2 * ghost_size : -ghost_size,
+        ],
+        local_vector_field[
+            :, ghost_size:-ghost_size, ghost_size:-ghost_size, 0:ghost_size
+        ],
+    )
+    # Along Y: comm with previous block
+    np.testing.assert_allclose(
+        local_vector_field[
+            :,
+            ghost_size:-ghost_size,
+            ghost_size : 2 * ghost_size,
+            ghost_size:-ghost_size,
+        ],
+        local_vector_field[
+            :,
+            ghost_size:-ghost_size,
+            -ghost_size : local_vector_field.shape[2],
+            ghost_size:-ghost_size,
+        ],
+    )
+    # Along Y: comm with next block
+    np.testing.assert_allclose(
+        local_vector_field[
+            :,
+            ghost_size:-ghost_size,
+            -2 * ghost_size : -ghost_size,
+            ghost_size:-ghost_size,
+        ],
+        local_vector_field[
+            :, ghost_size:-ghost_size, 0:ghost_size, ghost_size:-ghost_size
+        ],
+    )
+    # Along Z: comm with previous block
+    np.testing.assert_allclose(
+        local_vector_field[
+            :,
+            ghost_size : 2 * ghost_size,
+            ghost_size:-ghost_size,
+            ghost_size:-ghost_size,
+        ],
+        local_vector_field[
+            :,
+            -ghost_size : local_vector_field.shape[1],
+            ghost_size:-ghost_size,
+            ghost_size:-ghost_size,
+        ],
+    )
+    # Along Z: comm with next block
+    np.testing.assert_allclose(
+        local_vector_field[
+            :,
+            -2 * ghost_size : -ghost_size,
+            ghost_size:-ghost_size,
+            ghost_size:-ghost_size,
+        ],
+        local_vector_field[
+            :, 0:ghost_size, ghost_size:-ghost_size, ghost_size:-ghost_size
+        ],
     )


### PR DESCRIPTION
Fixes #140 

Here I decided to make the ghosting function name explicit, instead of passing in a `field_type` argument, to avoid dealing with `field_type` value checks and if-else branches to call the correct function. Rather, the user has to know apriori what type of fields they are ghosting, and correspondingly call the correct function.