### PR TITLE
Ghost corner cells

### DIFF
--- a/sopht_mpi/simulator/flow/flow_simulators_mpi_2d.py
+++ b/sopht_mpi/simulator/flow/flow_simulators_mpi_2d.py
@@ -99,8 +99,12 @@ class UnboundedFlowSimulator2D:
             real_t=self.real_t,
             rank_distribution=self.rank_distribution,
         )
+        # Unbounded (i.e. non periodic) 2D flow solver with mpi4py-fft (only slabs
+        # decomp) does not need full exchange in ghost communicator.
         self.mpi_ghost_exchange_communicator = MPIGhostCommunicator2D(
-            ghost_size=self.ghost_size, mpi_construct=self.mpi_construct
+            ghost_size=self.ghost_size,
+            mpi_construct=self.mpi_construct,
+            full_exchange=False,
         )
 
     def init_domain(self):

--- a/sopht_mpi/utils/mpi_utils_3d.py
+++ b/sopht_mpi/utils/mpi_utils_3d.py
@@ -16,7 +16,7 @@ class MPIConstruct3D:
         grid_size_z,
         grid_size_y,
         grid_size_x,
-        periodic_flag=False,
+        periodic_domain=False,
         real_t=np.float64,
         rank_distribution=None,
     ):
@@ -26,6 +26,7 @@ class MPIConstruct3D:
         # Set the MPI dtype generator based on precision
         self.dtype_generator = MPI.FLOAT if real_t == np.float32 else MPI.DOUBLE
         # Setup MPI environment
+        self.periodic_domain = periodic_domain
         self.world = MPI.COMM_WORLD
         # Automatically create topologies
         if rank_distribution is None:
@@ -36,8 +37,10 @@ class MPIConstruct3D:
         else:
             self.rank_distribution = rank_distribution
         if 1 not in self.rank_distribution:
-            raise ValueError(
-                f"Rank distribution {self.rank_distribution} needs to be"
+            # Log warning here for more generic use.
+            # mpi4py-fft will take care of throwing errors if fft is invoked later.
+            logger.warning(
+                f"Rank distribution {self.rank_distribution} needs to be "
                 "aligned in at least one direction for fft"
             )
         self.grid_topology = MPI.Compute_dims(
@@ -59,7 +62,7 @@ class MPIConstruct3D:
 
         # Create Cartesian grid communicator
         self.grid = self.world.Create_cart(
-            self.grid_topology, periods=periodic_flag, reorder=False
+            self.grid_topology, periods=self.periodic_domain, reorder=False
         )
         # Determine neighbours in all directions
         self.previous_grid_along = np.zeros(self.grid_dim).astype(int)
@@ -83,13 +86,36 @@ class MPIConstruct3D:
 class MPIGhostCommunicator3D:
     """
     Class exclusive for ghost communication across ranks, initialises data types
-    that will be used for comm. in both blocking and non-blocking styles. Builds
-    dtypes based on ghost_size (determined from stencil width of the kernel)
-    This class wont be seen by the user, rather based on stencils we determine
-    the properties here.
+    for communication based on ghost_size (determined from stencil width of the kernel).
+
+    Here we refer the ghost cells following the terminologies for cubes
+    (https://en.wikipedia.org/wiki/Cube): "The has 6 faces, 12 edges, and 8 vertices."
+    Consider a face of the cube in the ghost zone as illustrated below.
+
+    v e e e e e v <- vertex (corner)
+    e f f f f f e
+    e f f f f f e <- edge (side)
+    e f f f f f e
+    v e e e e e v
+
+    (v) vertex ghost cell
+    (e) edge ghost cell
+    (f) face ghost cell
+
+    Note
+    ---
+    `full_exchange` allows for exchanges ghost cells on the vertices, edges and faces of
+    the local domain (see illustration above). The full exchange mode is required only
+    when Eulerian-to-Lagrangian (structured-to-unstructured) grid interpolation is
+    performed. Similar to the 2D ghost communicator, we won't need the full exchange
+    mode even when the interpolation is performed if the domain decomposition mode
+    is slabs (unless a periodic flow simulator is employed). In the case where domain
+    decomposition mode is pencils (in 3D, mpi4py-fft allows for both slabs and pencils),
+    full exchange is needed if the structured-to-unstructured grid interpolation is
+    performed.
     """
 
-    def __init__(self, ghost_size, mpi_construct):
+    def __init__(self, ghost_size, mpi_construct, full_exchange=True):
         # extra width needed for kernel computation
         if ghost_size <= 0 and not isinstance(ghost_size, int):
             raise ValueError(
@@ -98,188 +124,1003 @@ class MPIGhostCommunicator3D:
             )
         self.ghost_size = ghost_size
         self.mpi_construct = mpi_construct
-        # define field_size variable for local field size (which includes ghost)
-        self.field_size = mpi_construct.local_grid_size + 2 * self.ghost_size
+        self.full_exchange = full_exchange
+        self.grid_coord = np.array(self.mpi_construct.grid.coords)
 
-        # Set datatypes for ghost communication
-        # Note: these can be written in a more involved, but perhaps faster way.
-        # Keeping this for now for its readibility and easy implementation.
-        # Using the Create_subarray approach, each type for sending / receiving
-        # needs to be initialized based on their starting index location. In
-        # each dimension, we have 2 ghost layers to be sent (to next & prev) and
-        # 2 corresponding receiving layers (from next & prev). This amounts to
-        # (2 type for send/recv) * (2 dir along each dim) * (3 dim) = 12 type
-        # Along X (next)
-        self.send_next_along_x_type = mpi_construct.dtype_generator.Create_subarray(
-            sizes=self.field_size,
-            subsizes=[self.field_size[0], self.field_size[1], self.ghost_size],
-            starts=[0, 0, self.field_size[2] - 2 * self.ghost_size],
-        )
-        self.send_next_along_x_type.Commit()
-        self.recv_next_along_x_type = mpi_construct.dtype_generator.Create_subarray(
-            sizes=self.field_size,
-            subsizes=[self.field_size[0], self.field_size[1], self.ghost_size],
-            starts=[0, 0, self.field_size[2] - self.ghost_size],
-        )
-        self.recv_next_along_x_type.Commit()
-        # Along X (prev)
-        self.send_previous_along_x_type = mpi_construct.dtype_generator.Create_subarray(
-            sizes=self.field_size,
-            subsizes=[self.field_size[0], self.field_size[1], self.ghost_size],
-            starts=[0, 0, self.ghost_size],
-        )
-        self.send_previous_along_x_type.Commit()
-        self.recv_previous_along_x_type = mpi_construct.dtype_generator.Create_subarray(
-            sizes=self.field_size,
-            subsizes=[self.field_size[0], self.field_size[1], self.ghost_size],
-            starts=[0, 0, 0],
-        )
-        self.recv_previous_along_x_type.Commit()
-        # Along Y (next)
-        self.send_next_along_y_type = mpi_construct.dtype_generator.Create_subarray(
-            sizes=self.field_size,
-            subsizes=[self.field_size[0], self.ghost_size, self.field_size[2]],
-            starts=[0, self.field_size[1] - 2 * self.ghost_size, 0],
-        )
-        self.send_next_along_y_type.Commit()
-        self.recv_next_along_y_type = mpi_construct.dtype_generator.Create_subarray(
-            sizes=self.field_size,
-            subsizes=[self.field_size[0], self.ghost_size, self.field_size[2]],
-            starts=[0, self.field_size[1] - self.ghost_size, 0],
-        )
-        self.recv_next_along_y_type.Commit()
-        # Along Y (prev)
-        self.send_previous_along_y_type = mpi_construct.dtype_generator.Create_subarray(
-            sizes=self.field_size,
-            subsizes=[self.field_size[0], self.ghost_size, self.field_size[2]],
-            starts=[0, self.ghost_size, 0],
-        )
-        self.send_previous_along_y_type.Commit()
-        self.recv_previous_along_y_type = mpi_construct.dtype_generator.Create_subarray(
-            sizes=self.field_size,
-            subsizes=[self.field_size[0], self.ghost_size, self.field_size[2]],
-            starts=[0, 0, 0],
-        )
-        self.recv_previous_along_y_type.Commit()
-
-        # Along Z (next)
-        self.send_next_along_z_type = mpi_construct.dtype_generator.Create_subarray(
-            sizes=self.field_size,
-            subsizes=[self.ghost_size, self.field_size[1], self.field_size[2]],
-            starts=[self.field_size[0] - 2 * self.ghost_size, 0, 0],
-        )
-        self.send_next_along_z_type.Commit()
-        self.recv_next_along_z_type = mpi_construct.dtype_generator.Create_subarray(
-            sizes=self.field_size,
-            subsizes=[self.ghost_size, self.field_size[1], self.field_size[2]],
-            starts=[self.field_size[0] - self.ghost_size, 0, 0],
-        )
-        self.recv_next_along_z_type.Commit()
-        # Along Z (prev)
-        self.send_previous_along_z_type = mpi_construct.dtype_generator.Create_subarray(
-            sizes=self.field_size,
-            subsizes=[self.ghost_size, self.field_size[1], self.field_size[2]],
-            starts=[self.ghost_size, 0, 0],
-        )
-        self.send_previous_along_z_type.Commit()
-        self.recv_previous_along_z_type = mpi_construct.dtype_generator.Create_subarray(
-            sizes=self.field_size,
-            subsizes=[self.ghost_size, self.field_size[1], self.field_size[2]],
-            starts=[0, 0, 0],
-        )
-        self.recv_previous_along_z_type.Commit()
+        # Initialize data types
+        self.init_datatypes()
 
         # Initialize requests list for non-blocking comm
         self.comm_requests = []
 
-    def exchange_scalar_field_init(self, local_field):
+        if self.full_exchange:
+            self.exchange_scalar_field_init = self.exchange_scalar_field_full_init
+        else:
+            self.exchange_scalar_field_init = self.exchange_scalar_field_faces_init
+
+    def init_datatypes(self):
         """
-        Exchange ghost data between neighbors.
+        Set datatypes for ghost communication on 6 faces, 12 edges and 8 vertices.
+        Each datatype will have a send and recv, giving a total of
+        (6 + 12 + 8) * 2 = 52 datatypes.
+
+        Note
+        ---
+        Here we are using the Create_subarray approach, each type for send/recv needs to
+        be initialized based on their starting index location. Alternatively, we can use
+        Create_vector approach which is more involved, but perhaps faster way.
+        Keeping subarray approach for now for its readibility and easy implementation.
+
+        For simplicity and readability, we use coordinate system (z, y, x) as used in
+        grid topology to define direction for send and recv. For example, when sending
+        along the (0, -1, +1) direction (i.e. along XY-plane in the positive X and
+        negative Y direction), we denote the data type name as `send_along_0_ny_px_type`
+        where 0, ny and px denotes 0 in Z, negative in Y, and positive in X coord shift,
+        respectively.
+        """
+        # define field_size variable for local field size (which includes ghost)
+        self.field_size_with_ghost = (
+            self.mpi_construct.local_grid_size + 2 * self.ghost_size
+        )
+        self.field_size = self.mpi_construct.local_grid_size
+
+        # (1) For faces data
+        # Since there are 6 faces on a cube, each with a send and recv datatypes, we
+        # need 6 * 2 = 12 data types
+        # Comm. along +X direction: send to (0, 0, +1) with recv from (0, 0, -1) block
+        self.send_to_0_0_px_type = self.mpi_construct.dtype_generator.Create_subarray(
+            sizes=self.field_size_with_ghost,
+            subsizes=[self.field_size[0], self.field_size[1], self.ghost_size],
+            starts=[
+                self.ghost_size,
+                self.ghost_size,
+                self.field_size_with_ghost[2] - 2 * self.ghost_size,
+            ],
+        )
+        self.send_to_0_0_px_type.Commit()
+        self.recv_from_0_0_nx_type = self.mpi_construct.dtype_generator.Create_subarray(
+            sizes=self.field_size_with_ghost,
+            subsizes=[self.field_size[0], self.field_size[1], self.ghost_size],
+            starts=[self.ghost_size, self.ghost_size, 0],
+        )
+        self.recv_from_0_0_nx_type.Commit()
+        # Comm. along -X direction: send to (-1, 0, 0) with recv from (+1, 0, 0) block
+        self.send_to_0_0_nx_type = self.mpi_construct.dtype_generator.Create_subarray(
+            sizes=self.field_size_with_ghost,
+            subsizes=[self.field_size[0], self.field_size[1], self.ghost_size],
+            starts=[self.ghost_size, self.ghost_size, self.ghost_size],
+        )
+        self.send_to_0_0_nx_type.Commit()
+        self.recv_from_0_0_px_type = self.mpi_construct.dtype_generator.Create_subarray(
+            sizes=self.field_size_with_ghost,
+            subsizes=[self.field_size[0], self.field_size[1], self.ghost_size],
+            starts=[
+                self.ghost_size,
+                self.ghost_size,
+                self.field_size_with_ghost[2] - self.ghost_size,
+            ],
+        )
+        self.recv_from_0_0_px_type.Commit()
+
+        # Comm. along +Y direction: send to (0, +1, 0) with recv from (0, -1, 0) block
+        self.send_to_0_py_0_type = self.mpi_construct.dtype_generator.Create_subarray(
+            sizes=self.field_size_with_ghost,
+            subsizes=[self.field_size[0], self.ghost_size, self.field_size[2]],
+            starts=[
+                self.ghost_size,
+                self.field_size_with_ghost[1] - 2 * self.ghost_size,
+                self.ghost_size,
+            ],
+        )
+        self.send_to_0_py_0_type.Commit()
+        self.recv_from_0_ny_0_type = self.mpi_construct.dtype_generator.Create_subarray(
+            sizes=self.field_size_with_ghost,
+            subsizes=[self.field_size[0], self.ghost_size, self.field_size[2]],
+            starts=[self.ghost_size, 0, self.ghost_size],
+        )
+        self.recv_from_0_ny_0_type.Commit()
+        # Comm. along -Y direction: send to (0, -1, 0) with recv from (0, +1, 0) block
+        self.send_to_0_ny_0_type = self.mpi_construct.dtype_generator.Create_subarray(
+            sizes=self.field_size_with_ghost,
+            subsizes=[self.field_size[0], self.ghost_size, self.field_size[2]],
+            starts=[self.ghost_size, self.ghost_size, self.ghost_size],
+        )
+        self.send_to_0_ny_0_type.Commit()
+        self.recv_from_0_py_0_type = self.mpi_construct.dtype_generator.Create_subarray(
+            sizes=self.field_size_with_ghost,
+            subsizes=[self.field_size[0], self.ghost_size, self.field_size[2]],
+            starts=[
+                self.ghost_size,
+                self.field_size_with_ghost[1] - self.ghost_size,
+                self.ghost_size,
+            ],
+        )
+        self.recv_from_0_py_0_type.Commit()
+
+        # Comm. along +Z direction: send to (+1, 0, 0) with recv from (-1, 0, 0) block
+        self.send_to_pz_0_0_type = self.mpi_construct.dtype_generator.Create_subarray(
+            sizes=self.field_size_with_ghost,
+            subsizes=[self.ghost_size, self.field_size[1], self.field_size[2]],
+            starts=[
+                self.field_size_with_ghost[0] - 2 * self.ghost_size,
+                self.ghost_size,
+                self.ghost_size,
+            ],
+        )
+        self.send_to_pz_0_0_type.Commit()
+        self.recv_from_nz_0_0_type = self.mpi_construct.dtype_generator.Create_subarray(
+            sizes=self.field_size_with_ghost,
+            subsizes=[self.ghost_size, self.field_size[1], self.field_size[2]],
+            starts=[0, self.ghost_size, self.ghost_size],
+        )
+        self.recv_from_nz_0_0_type.Commit()
+        # Comm. along -Z direction: send to (-1, 0, 0) with recv from (+1, 0, 0) block
+        self.send_to_nz_0_0_type = self.mpi_construct.dtype_generator.Create_subarray(
+            sizes=self.field_size_with_ghost,
+            subsizes=[self.ghost_size, self.field_size[1], self.field_size[2]],
+            starts=[self.ghost_size, self.ghost_size, self.ghost_size],
+        )
+        self.send_to_nz_0_0_type.Commit()
+        self.recv_from_pz_0_0_type = self.mpi_construct.dtype_generator.Create_subarray(
+            sizes=self.field_size_with_ghost,
+            subsizes=[self.ghost_size, self.field_size[1], self.field_size[2]],
+            starts=[
+                self.field_size_with_ghost[0] - self.ghost_size,
+                self.ghost_size,
+                self.ghost_size,
+            ],
+        )
+        self.recv_from_pz_0_0_type.Commit()
+
+        if self.full_exchange:
+            # (2) For edges
+            # Since there are 12 edges on a cube, each with a send and recv datatypes,
+            # we need 12 * 2 = 24 datatypes
+            # Comm. along +Y, +X: send to (0, +1, +1) with recv from (0, -1, -1) block
+            self.send_to_0_py_px_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.field_size[0], self.ghost_size, self.ghost_size],
+                    starts=[
+                        self.ghost_size,
+                        self.field_size_with_ghost[1] - 2 * self.ghost_size,
+                        self.field_size_with_ghost[2] - 2 * self.ghost_size,
+                    ],
+                )
+            )
+            self.send_to_0_py_px_type.Commit()
+            self.recv_from_0_ny_nx_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.field_size[0], self.ghost_size, self.ghost_size],
+                    starts=[self.ghost_size, 0, 0],
+                )
+            )
+            self.recv_from_0_ny_nx_type.Commit()
+            # Comm. along -Y, +X: send to (0, -1, +1) with recv from (0, +1, -1) block
+            self.send_to_0_ny_px_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.field_size[0], self.ghost_size, self.ghost_size],
+                    starts=[
+                        self.ghost_size,
+                        self.ghost_size,
+                        self.field_size_with_ghost[2] - 2 * self.ghost_size,
+                    ],
+                )
+            )
+            self.send_to_0_ny_px_type.Commit()
+            self.recv_from_0_py_nx_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.field_size[0], self.ghost_size, self.ghost_size],
+                    starts=[
+                        self.ghost_size,
+                        self.field_size_with_ghost[1] - self.ghost_size,
+                        0,
+                    ],
+                )
+            )
+            self.recv_from_0_py_nx_type.Commit()
+            # Comm. along +Y, -X: send to (0, +1, -1) with recv from (0, -1, +1) block
+            self.send_to_0_py_nx_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.field_size[0], self.ghost_size, self.ghost_size],
+                    starts=[
+                        self.ghost_size,
+                        self.field_size_with_ghost[1] - 2 * self.ghost_size,
+                        self.ghost_size,
+                    ],
+                )
+            )
+            self.send_to_0_py_nx_type.Commit()
+            self.recv_from_0_ny_px_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.field_size[0], self.ghost_size, self.ghost_size],
+                    starts=[
+                        self.ghost_size,
+                        0,
+                        self.field_size_with_ghost[2] - self.ghost_size,
+                    ],
+                )
+            )
+            self.recv_from_0_ny_px_type.Commit()
+            # Comm. along -Y, -X: send to (0, -1, -1) with recv from (0, +1, +1) block
+            self.send_to_0_ny_nx_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.field_size[0], self.ghost_size, self.ghost_size],
+                    starts=[self.ghost_size, self.ghost_size, self.ghost_size],
+                )
+            )
+            self.send_to_0_ny_nx_type.Commit()
+            self.recv_from_0_py_px_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.field_size[0], self.ghost_size, self.ghost_size],
+                    starts=[
+                        self.ghost_size,
+                        self.field_size_with_ghost[1] - self.ghost_size,
+                        self.field_size_with_ghost[2] - self.ghost_size,
+                    ],
+                )
+            )
+            self.recv_from_0_py_px_type.Commit()
+
+            # Comm. along +Z, +X: send to (+1, 0, +1) with recv from (-1, 0, -1) block
+            self.send_to_pz_0_px_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.ghost_size, self.field_size[1], self.ghost_size],
+                    starts=[
+                        self.field_size_with_ghost[0] - 2 * self.ghost_size,
+                        self.ghost_size,
+                        self.field_size_with_ghost[2] - 2 * self.ghost_size,
+                    ],
+                )
+            )
+            self.send_to_pz_0_px_type.Commit()
+            self.recv_from_nz_0_nx_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.ghost_size, self.field_size[1], self.ghost_size],
+                    starts=[0, self.ghost_size, 0],
+                )
+            )
+            self.recv_from_nz_0_nx_type.Commit()
+            # Comm. along -Z, +X: send to (-1, 0, +1) with recv from (+1, 0, -1) block
+            self.send_to_nz_0_px_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.ghost_size, self.field_size[1], self.ghost_size],
+                    starts=[
+                        self.ghost_size,
+                        self.ghost_size,
+                        self.field_size_with_ghost[2] - 2 * self.ghost_size,
+                    ],
+                )
+            )
+            self.send_to_nz_0_px_type.Commit()
+            self.recv_from_pz_0_nx_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.ghost_size, self.field_size[1], self.ghost_size],
+                    starts=[
+                        self.field_size_with_ghost[0] - self.ghost_size,
+                        self.ghost_size,
+                        0,
+                    ],
+                )
+            )
+            self.recv_from_pz_0_nx_type.Commit()
+            # Comm. along +Z, -X: send to (+1, 0, -1) with recv from (-1, 0, +1) block
+            self.send_to_pz_0_nx_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.ghost_size, self.field_size[1], self.ghost_size],
+                    starts=[
+                        self.field_size_with_ghost[0] - 2 * self.ghost_size,
+                        self.ghost_size,
+                        self.ghost_size,
+                    ],
+                )
+            )
+            self.send_to_pz_0_nx_type.Commit()
+            self.recv_from_nz_0_px_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.ghost_size, self.field_size[1], self.ghost_size],
+                    starts=[
+                        0,
+                        self.ghost_size,
+                        self.field_size_with_ghost[2] - self.ghost_size,
+                    ],
+                )
+            )
+            self.recv_from_nz_0_px_type.Commit()
+            # Comm. along -Z, -X: send to (-1, 0, -1) with recv from (+1, 0, +1) block
+            self.send_to_nz_0_nx_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.ghost_size, self.field_size[1], self.ghost_size],
+                    starts=[self.ghost_size, self.ghost_size, self.ghost_size],
+                )
+            )
+            self.send_to_nz_0_nx_type.Commit()
+            self.recv_from_pz_0_px_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.ghost_size, self.field_size[1], self.ghost_size],
+                    starts=[
+                        self.field_size_with_ghost[0] - self.ghost_size,
+                        self.ghost_size,
+                        self.field_size_with_ghost[2] - self.ghost_size,
+                    ],
+                )
+            )
+            self.recv_from_pz_0_px_type.Commit()
+
+            # Comm. along +Z, +Y: send to (+1, +1, 0) with recv from (-1, -1, 0) block
+            self.send_to_pz_py_0_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.ghost_size, self.ghost_size, self.field_size[2]],
+                    starts=[
+                        self.field_size_with_ghost[0] - 2 * self.ghost_size,
+                        self.field_size_with_ghost[1] - 2 * self.ghost_size,
+                        self.ghost_size,
+                    ],
+                )
+            )
+            self.send_to_pz_py_0_type.Commit()
+            self.recv_from_nz_ny_0_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.ghost_size, self.ghost_size, self.field_size[2]],
+                    starts=[0, 0, self.ghost_size],
+                )
+            )
+            self.recv_from_nz_ny_0_type.Commit()
+            # Comm. along -Z, +Y: send to (-1, +1, 0) with recv from (+1, -1, 0) block
+            self.send_to_nz_py_0_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.ghost_size, self.ghost_size, self.field_size[2]],
+                    starts=[
+                        self.ghost_size,
+                        self.field_size_with_ghost[1] - 2 * self.ghost_size,
+                        self.ghost_size,
+                    ],
+                )
+            )
+            self.send_to_nz_py_0_type.Commit()
+            self.recv_from_pz_ny_0_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.ghost_size, self.ghost_size, self.field_size[2]],
+                    starts=[
+                        self.field_size_with_ghost[0] - self.ghost_size,
+                        0,
+                        self.ghost_size,
+                    ],
+                )
+            )
+            self.recv_from_pz_ny_0_type.Commit()
+            # Comm. along +Z, -Y: send to (+1, -1, 0) with recv from (-1, +1, 0) block
+            self.send_to_pz_ny_0_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.ghost_size, self.ghost_size, self.field_size[2]],
+                    starts=[
+                        self.field_size_with_ghost[0] - 2 * self.ghost_size,
+                        self.ghost_size,
+                        self.ghost_size,
+                    ],
+                )
+            )
+            self.send_to_pz_ny_0_type.Commit()
+            self.recv_from_nz_py_0_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.ghost_size, self.ghost_size, self.field_size[2]],
+                    starts=[
+                        0,
+                        self.field_size_with_ghost[1] - self.ghost_size,
+                        self.ghost_size,
+                    ],
+                )
+            )
+            self.recv_from_nz_py_0_type.Commit()
+            # Comm. along -Z, -Y: send to (-1, -1, 0) with recv from (+1, +1, 0) block
+            self.send_to_nz_ny_0_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.ghost_size, self.ghost_size, self.field_size[2]],
+                    starts=[self.ghost_size, self.ghost_size, self.ghost_size],
+                )
+            )
+            self.send_to_nz_ny_0_type.Commit()
+            self.recv_from_pz_py_0_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.ghost_size, self.ghost_size, self.field_size[2]],
+                    starts=[
+                        self.field_size_with_ghost[0] - self.ghost_size,
+                        self.field_size_with_ghost[1] - self.ghost_size,
+                        self.ghost_size,
+                    ],
+                )
+            )
+            self.recv_from_pz_py_0_type.Commit()
+
+            # (3) For vertices
+            # Since there are 8 vertices on a cube, each with a send and recv datatypes,
+            # we need 8 * 2 = 16 datatypes
+            # Comm. along +Z, +Y, +X: send to (+1, +1, +1) with recv from (-1, -1, -1) block
+            self.send_to_pz_py_px_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.ghost_size, self.ghost_size, self.ghost_size],
+                    starts=[
+                        self.field_size_with_ghost[0] - 2 * self.ghost_size,
+                        self.field_size_with_ghost[1] - 2 * self.ghost_size,
+                        self.field_size_with_ghost[2] - 2 * self.ghost_size,
+                    ],
+                )
+            )
+            self.send_to_pz_py_px_type.Commit()
+            self.recv_from_nz_ny_nx_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.ghost_size, self.ghost_size, self.ghost_size],
+                    starts=[0, 0, 0],
+                )
+            )
+            self.recv_from_nz_ny_nx_type.Commit()
+            # Comm. along -Z, +Y, +X: send to (-1, +1, +1) with recv from (+1, -1, -1) block
+            self.send_to_nz_py_px_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.ghost_size, self.ghost_size, self.ghost_size],
+                    starts=[
+                        self.ghost_size,
+                        self.field_size_with_ghost[1] - 2 * self.ghost_size,
+                        self.field_size_with_ghost[2] - 2 * self.ghost_size,
+                    ],
+                )
+            )
+            self.send_to_nz_py_px_type.Commit()
+            self.recv_from_pz_ny_nx_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.ghost_size, self.ghost_size, self.ghost_size],
+                    starts=[self.field_size_with_ghost[0] - self.ghost_size, 0, 0],
+                )
+            )
+            self.recv_from_pz_ny_nx_type.Commit()
+            # Comm. along +Z, -Y, +X: send to (+1, -1, +1) with recv from (-1, +1, -1) block
+            self.send_to_pz_ny_px_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.ghost_size, self.ghost_size, self.ghost_size],
+                    starts=[
+                        self.field_size_with_ghost[0] - 2 * self.ghost_size,
+                        self.ghost_size,
+                        self.field_size_with_ghost[2] - 2 * self.ghost_size,
+                    ],
+                )
+            )
+            self.send_to_pz_ny_px_type.Commit()
+            self.recv_from_nz_py_nx_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.ghost_size, self.ghost_size, self.ghost_size],
+                    starts=[0, self.field_size_with_ghost[1] - self.ghost_size, 0],
+                )
+            )
+            self.recv_from_nz_py_nx_type.Commit()
+            # Comm. along +Z, +Y, -X: send to (+1, +1, -1) with recv from (-1, -1, +1) block
+            self.send_to_pz_py_nx_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.ghost_size, self.ghost_size, self.ghost_size],
+                    starts=[
+                        self.field_size_with_ghost[0] - 2 * self.ghost_size,
+                        self.field_size_with_ghost[1] - 2 * self.ghost_size,
+                        self.ghost_size,
+                    ],
+                )
+            )
+            self.send_to_pz_py_nx_type.Commit()
+            self.recv_from_nz_ny_px_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.ghost_size, self.ghost_size, self.ghost_size],
+                    starts=[0, 0, self.field_size_with_ghost[2] - self.ghost_size],
+                )
+            )
+            self.recv_from_nz_ny_px_type.Commit()
+            # Comm. along -Z, -Y, +X: send to (-1, -1, +1) with recv from (+1, +1, -1) block
+            self.send_to_nz_ny_px_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.ghost_size, self.ghost_size, self.ghost_size],
+                    starts=[
+                        self.ghost_size,
+                        self.ghost_size,
+                        self.field_size_with_ghost[2] - 2 * self.ghost_size,
+                    ],
+                )
+            )
+            self.send_to_nz_ny_px_type.Commit()
+            self.recv_from_pz_py_nx_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.ghost_size, self.ghost_size, self.ghost_size],
+                    starts=[
+                        self.field_size_with_ghost[0] - self.ghost_size,
+                        self.field_size_with_ghost[1] - self.ghost_size,
+                        0,
+                    ],
+                )
+            )
+            self.recv_from_pz_py_nx_type.Commit()
+            # Comm. along -Z, +Y, -X: send to (-1, +1, -1) with recv from (+1, -1, +1) block
+            self.send_to_nz_py_nx_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.ghost_size, self.ghost_size, self.ghost_size],
+                    starts=[
+                        self.ghost_size,
+                        self.field_size_with_ghost[1] - 2 * self.ghost_size,
+                        self.ghost_size,
+                    ],
+                )
+            )
+            self.send_to_nz_py_nx_type.Commit()
+            self.recv_from_pz_ny_px_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.ghost_size, self.ghost_size, self.ghost_size],
+                    starts=[
+                        self.field_size_with_ghost[0] - self.ghost_size,
+                        0,
+                        self.field_size_with_ghost[2] - self.ghost_size,
+                    ],
+                )
+            )
+            self.recv_from_pz_ny_px_type.Commit()
+            # Comm. along +Z, -Y, -X: send to (+1, -1, -1) with recv from (-1, +1, +1) block
+            self.send_to_pz_ny_nx_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.ghost_size, self.ghost_size, self.ghost_size],
+                    starts=[
+                        self.field_size_with_ghost[0] - 2 * self.ghost_size,
+                        self.ghost_size,
+                        self.ghost_size,
+                    ],
+                )
+            )
+            self.send_to_pz_ny_nx_type.Commit()
+            self.recv_from_nz_py_px_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.ghost_size, self.ghost_size, self.ghost_size],
+                    starts=[
+                        0,
+                        self.field_size_with_ghost[1] - self.ghost_size,
+                        self.field_size_with_ghost[2] - self.ghost_size,
+                    ],
+                )
+            )
+            self.recv_from_nz_py_px_type.Commit()
+            # Comm. along -Z, -Y, -X: send to (-1, -1, -1) with recv from (+1, +1, +1) block
+            self.send_to_nz_ny_nx_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.ghost_size, self.ghost_size, self.ghost_size],
+                    starts=[self.ghost_size, self.ghost_size, self.ghost_size],
+                )
+            )
+            self.send_to_nz_ny_nx_type.Commit()
+            self.recv_from_pz_py_px_type = (
+                self.mpi_construct.dtype_generator.Create_subarray(
+                    sizes=self.field_size_with_ghost,
+                    subsizes=[self.ghost_size, self.ghost_size, self.ghost_size],
+                    starts=[
+                        self.field_size_with_ghost[0] - self.ghost_size,
+                        self.field_size_with_ghost[1] - self.ghost_size,
+                        self.field_size_with_ghost[2] - self.ghost_size,
+                    ],
+                )
+            )
+            self.recv_from_pz_py_px_type.Commit()
+
+    def _get_diagonally_shifted_coord_rank(self, coord_shift):
+        """Helper function to get diagonally shifted coords"""
+        shifted_coord = self.grid_coord + np.array(coord_shift)
+        if not self.mpi_construct.periodic_domain and (
+            np.any(shifted_coord >= self.mpi_construct.grid_topology)
+            or np.any(shifted_coord < 0)
+        ):
+            # The shifted coord is out of non-periodic domain
+            rank = MPI.PROC_NULL
+        else:
+            # Periodic domain is automatically taken care of in mpi cartersian grid
+            rank = self.mpi_construct.grid.Get_cart_rank(shifted_coord)
+        return rank
+
+    def exchange_scalar_field_faces_init(self, local_field):
+        """
+        Exchange scalar field ghost data on faces between neighbors.
         """
         # Lines below to make code more literal
         z_axis = 0
         y_axis = 1
         x_axis = 2
-        # Along X: send to previous block, receive from next block
+
+        # Comm. along +X direction: send to (0, 0, +1) with recv from (0, 0, -1) block
         self.comm_requests.append(
             self.mpi_construct.grid.Isend(
-                (local_field, self.send_previous_along_x_type),
-                dest=self.mpi_construct.previous_grid_along[x_axis],
-            )
-        )
-        self.comm_requests.append(
-            self.mpi_construct.grid.Irecv(
-                (local_field, self.recv_next_along_x_type),
-                source=self.mpi_construct.next_grid_along[x_axis],
-            )
-        )
-        # Along X: send to next block, receive from previous block
-        self.comm_requests.append(
-            self.mpi_construct.grid.Isend(
-                (local_field, self.send_next_along_x_type),
+                (local_field, self.send_to_0_0_px_type),
                 dest=self.mpi_construct.next_grid_along[x_axis],
             )
         )
         self.comm_requests.append(
             self.mpi_construct.grid.Irecv(
-                (local_field, self.recv_previous_along_x_type),
+                (local_field, self.recv_from_0_0_nx_type),
                 source=self.mpi_construct.previous_grid_along[x_axis],
             )
         )
-
-        # Along Y: send to previous block, receive from next block
+        # Comm. along -X direction: send to (0, 0, -1) with recv from (0, 0, +1) block
         self.comm_requests.append(
             self.mpi_construct.grid.Isend(
-                (local_field, self.send_previous_along_y_type),
-                dest=self.mpi_construct.previous_grid_along[y_axis],
+                (local_field, self.send_to_0_0_nx_type),
+                dest=self.mpi_construct.previous_grid_along[x_axis],
             )
         )
         self.comm_requests.append(
             self.mpi_construct.grid.Irecv(
-                (local_field, self.recv_next_along_y_type),
-                source=self.mpi_construct.next_grid_along[y_axis],
+                (local_field, self.recv_from_0_0_px_type),
+                source=self.mpi_construct.next_grid_along[x_axis],
             )
         )
-        # Along Y: send to next block, receive from previous block
+        # Comm. along +Y direction: send to (0, +1, 0) with recv from (0, -1, 0) block
         self.comm_requests.append(
             self.mpi_construct.grid.Isend(
-                (local_field, self.send_next_along_y_type),
+                (local_field, self.send_to_0_py_0_type),
                 dest=self.mpi_construct.next_grid_along[y_axis],
             )
         )
         self.comm_requests.append(
             self.mpi_construct.grid.Irecv(
-                (local_field, self.recv_previous_along_y_type),
+                (local_field, self.recv_from_0_ny_0_type),
                 source=self.mpi_construct.previous_grid_along[y_axis],
             )
         )
-
-        # Along Z: send to previous block, receive from next block
+        # Comm. along -Y direction: send to (0, -1, 0) with recv from (0, +1, 0) block
         self.comm_requests.append(
             self.mpi_construct.grid.Isend(
-                (local_field, self.send_previous_along_z_type),
-                dest=self.mpi_construct.previous_grid_along[z_axis],
+                (local_field, self.send_to_0_ny_0_type),
+                dest=self.mpi_construct.previous_grid_along[y_axis],
             )
         )
         self.comm_requests.append(
             self.mpi_construct.grid.Irecv(
-                (local_field, self.recv_next_along_z_type),
-                source=self.mpi_construct.next_grid_along[z_axis],
+                (local_field, self.recv_from_0_py_0_type),
+                source=self.mpi_construct.next_grid_along[y_axis],
             )
         )
-        # Along Z: send to next block, receive from previous block
+        # Comm. along +Z direction: send to (+1, 0, 0) with recv from (-1, 0, 0) block
         self.comm_requests.append(
             self.mpi_construct.grid.Isend(
-                (local_field, self.send_next_along_z_type),
+                (local_field, self.send_to_pz_0_0_type),
                 dest=self.mpi_construct.next_grid_along[z_axis],
             )
         )
         self.comm_requests.append(
             self.mpi_construct.grid.Irecv(
-                (local_field, self.recv_previous_along_z_type),
+                (local_field, self.recv_from_nz_0_0_type),
                 source=self.mpi_construct.previous_grid_along[z_axis],
             )
         )
+        # Comm. along -Z direction: send to (-1, 0, 0) with recv from (+1, 0, 0) block
+        self.comm_requests.append(
+            self.mpi_construct.grid.Isend(
+                (local_field, self.send_to_nz_0_0_type),
+                dest=self.mpi_construct.previous_grid_along[z_axis],
+            )
+        )
+        self.comm_requests.append(
+            self.mpi_construct.grid.Irecv(
+                (local_field, self.recv_from_pz_0_0_type),
+                source=self.mpi_construct.next_grid_along[z_axis],
+            )
+        )
+
+    def exchange_scalar_field_edges_init(self, local_field):
+        """
+        Exchange scalar field ghost data on edges between neighbors.
+        """
+        # Comm. along +Y, +X: send to (0, +1, +1) with recv from (0, -1, -1) block
+        self.comm_requests.append(
+            self.mpi_construct.grid.Isend(
+                (local_field, self.send_to_0_py_px_type),
+                dest=self._get_diagonally_shifted_coord_rank(coord_shift=[0, 1, 1]),
+            )
+        )
+        self.comm_requests.append(
+            self.mpi_construct.grid.Irecv(
+                (local_field, self.recv_from_0_ny_nx_type),
+                source=self._get_diagonally_shifted_coord_rank(coord_shift=[0, -1, -1]),
+            )
+        )
+        # Comm. along -Y, +X: send to (0, -1, +1) with recv from (0, +1, -1) block
+        self.comm_requests.append(
+            self.mpi_construct.grid.Isend(
+                (local_field, self.send_to_0_ny_px_type),
+                dest=self._get_diagonally_shifted_coord_rank(coord_shift=[0, -1, 1]),
+            )
+        )
+        self.comm_requests.append(
+            self.mpi_construct.grid.Irecv(
+                (local_field, self.recv_from_0_py_nx_type),
+                source=self._get_diagonally_shifted_coord_rank(coord_shift=[0, 1, -1]),
+            )
+        )
+        # Comm. along +Y, -X: send to (0, +1, -1) with recv from (0, -1, +1) block
+        self.comm_requests.append(
+            self.mpi_construct.grid.Isend(
+                (local_field, self.send_to_0_py_nx_type),
+                dest=self._get_diagonally_shifted_coord_rank(coord_shift=[0, 1, -1]),
+            )
+        )
+        self.comm_requests.append(
+            self.mpi_construct.grid.Irecv(
+                (local_field, self.recv_from_0_ny_px_type),
+                source=self._get_diagonally_shifted_coord_rank(coord_shift=[0, -1, 1]),
+            )
+        )
+        # Comm. along -Y, -X: send to (0, -1, -1) with recv from (0, +1, +1) block
+        self.comm_requests.append(
+            self.mpi_construct.grid.Isend(
+                (local_field, self.send_to_0_ny_nx_type),
+                dest=self._get_diagonally_shifted_coord_rank(coord_shift=[0, -1, -1]),
+            )
+        )
+        self.comm_requests.append(
+            self.mpi_construct.grid.Irecv(
+                (local_field, self.recv_from_0_py_px_type),
+                source=self._get_diagonally_shifted_coord_rank(coord_shift=[0, 1, 1]),
+            )
+        )
+        # Comm. along +Z, +X: send to (+1, 0, +1) with recv from (-1, 0, -1) block
+        self.comm_requests.append(
+            self.mpi_construct.grid.Isend(
+                (local_field, self.send_to_pz_0_px_type),
+                dest=self._get_diagonally_shifted_coord_rank(coord_shift=[1, 0, 1]),
+            )
+        )
+        self.comm_requests.append(
+            self.mpi_construct.grid.Irecv(
+                (local_field, self.recv_from_nz_0_nx_type),
+                source=self._get_diagonally_shifted_coord_rank(coord_shift=[-1, 0, -1]),
+            )
+        )
+        # Comm. along -Z, +X: send to (-1, 0, +1) with recv from (+1, 0, -1) block
+        self.comm_requests.append(
+            self.mpi_construct.grid.Isend(
+                (local_field, self.send_to_nz_0_px_type),
+                dest=self._get_diagonally_shifted_coord_rank(coord_shift=[-1, 0, 1]),
+            )
+        )
+        self.comm_requests.append(
+            self.mpi_construct.grid.Irecv(
+                (local_field, self.recv_from_pz_0_nx_type),
+                source=self._get_diagonally_shifted_coord_rank(coord_shift=[1, 0, -1]),
+            )
+        )
+        # Comm. along +Z, -X: send to (+1, 0, -1) with recv from (-1, 0, +1) block
+        self.comm_requests.append(
+            self.mpi_construct.grid.Isend(
+                (local_field, self.send_to_pz_0_nx_type),
+                dest=self._get_diagonally_shifted_coord_rank(coord_shift=[1, 0, -1]),
+            )
+        )
+        self.comm_requests.append(
+            self.mpi_construct.grid.Irecv(
+                (local_field, self.recv_from_nz_0_px_type),
+                source=self._get_diagonally_shifted_coord_rank(coord_shift=[-1, 0, 1]),
+            )
+        )
+        # Comm. along -Z, -X: send to (-1, 0, -1) with recv from (+1, 0, +1) block
+        self.comm_requests.append(
+            self.mpi_construct.grid.Isend(
+                (local_field, self.send_to_nz_0_nx_type),
+                dest=self._get_diagonally_shifted_coord_rank(coord_shift=[-1, 0, -1]),
+            )
+        )
+        self.comm_requests.append(
+            self.mpi_construct.grid.Irecv(
+                (local_field, self.recv_from_pz_0_px_type),
+                source=self._get_diagonally_shifted_coord_rank(coord_shift=[1, 0, 1]),
+            )
+        )
+        # Comm. along +Z, +Y: send to (+1, +1, 0) with recv from (-1, -1, 0) block
+        self.comm_requests.append(
+            self.mpi_construct.grid.Isend(
+                (local_field, self.send_to_pz_py_0_type),
+                dest=self._get_diagonally_shifted_coord_rank(coord_shift=[1, 1, 0]),
+            )
+        )
+        self.comm_requests.append(
+            self.mpi_construct.grid.Irecv(
+                (local_field, self.recv_from_nz_ny_0_type),
+                source=self._get_diagonally_shifted_coord_rank(coord_shift=[-1, -1, 0]),
+            )
+        )
+        # Comm. along -Z, +Y: send to (-1, +1, 0) with recv from (+1, -1, 0) block
+        self.comm_requests.append(
+            self.mpi_construct.grid.Isend(
+                (local_field, self.send_to_nz_py_0_type),
+                dest=self._get_diagonally_shifted_coord_rank(coord_shift=[-1, 1, 0]),
+            )
+        )
+        self.comm_requests.append(
+            self.mpi_construct.grid.Irecv(
+                (local_field, self.recv_from_pz_ny_0_type),
+                source=self._get_diagonally_shifted_coord_rank(coord_shift=[1, -1, 0]),
+            )
+        )
+        # Comm. along +Z, -Y: send to (+1, -1, 0) with recv from (-1, +1, 0) block
+        self.comm_requests.append(
+            self.mpi_construct.grid.Isend(
+                (local_field, self.send_to_pz_ny_0_type),
+                dest=self._get_diagonally_shifted_coord_rank(coord_shift=[1, -1, 0]),
+            )
+        )
+        self.comm_requests.append(
+            self.mpi_construct.grid.Irecv(
+                (local_field, self.recv_from_nz_py_0_type),
+                source=self._get_diagonally_shifted_coord_rank(coord_shift=[-1, 1, 0]),
+            )
+        )
+        # Comm. along -Z, -Y: send to (-1, -1, 0) with recv from (+1, +1, 0) block
+        self.comm_requests.append(
+            self.mpi_construct.grid.Isend(
+                (local_field, self.send_to_nz_ny_0_type),
+                dest=self._get_diagonally_shifted_coord_rank(coord_shift=[-1, -1, 0]),
+            )
+        )
+        self.comm_requests.append(
+            self.mpi_construct.grid.Irecv(
+                (local_field, self.recv_from_pz_py_0_type),
+                source=self._get_diagonally_shifted_coord_rank(coord_shift=[1, 1, 0]),
+            )
+        )
+
+    def exchange_scalar_field_vertices_init(self, local_field):
+        """
+        Exchange scalar field ghost data on vertices between neighbors.
+        """
+        # Comm. along +Z, +Y, +X: send to (+1, +1, +1) with recv from (-1, -1, -1) block
+        self.comm_requests.append(
+            self.mpi_construct.grid.Isend(
+                (local_field, self.send_to_pz_py_px_type),
+                dest=self._get_diagonally_shifted_coord_rank(coord_shift=[1, 1, 1]),
+            )
+        )
+        self.comm_requests.append(
+            self.mpi_construct.grid.Irecv(
+                (local_field, self.recv_from_nz_ny_nx_type),
+                source=self._get_diagonally_shifted_coord_rank(
+                    coord_shift=[-1, -1, -1]
+                ),
+            )
+        )
+        # Comm. along -Z, +Y, +X: send to (-1, +1, +1) with recv from (+1, -1, -1) block
+        self.comm_requests.append(
+            self.mpi_construct.grid.Isend(
+                (local_field, self.send_to_nz_py_px_type),
+                dest=self._get_diagonally_shifted_coord_rank(coord_shift=[-1, 1, 1]),
+            )
+        )
+        self.comm_requests.append(
+            self.mpi_construct.grid.Irecv(
+                (local_field, self.recv_from_pz_ny_nx_type),
+                source=self._get_diagonally_shifted_coord_rank(coord_shift=[1, -1, -1]),
+            )
+        )
+        # Comm. along +Z, -Y, +X: send to (+1, -1, +1) with recv from (-1, +1, -1) block
+        self.comm_requests.append(
+            self.mpi_construct.grid.Isend(
+                (local_field, self.send_to_pz_ny_px_type),
+                dest=self._get_diagonally_shifted_coord_rank(coord_shift=[1, -1, 1]),
+            )
+        )
+        self.comm_requests.append(
+            self.mpi_construct.grid.Irecv(
+                (local_field, self.recv_from_nz_py_nx_type),
+                source=self._get_diagonally_shifted_coord_rank(coord_shift=[-1, 1, -1]),
+            )
+        )
+        # Comm. along +Z, +Y, -X: send to (+1, +1, -1) with recv from (-1, -1, +1) block
+        self.comm_requests.append(
+            self.mpi_construct.grid.Isend(
+                (local_field, self.send_to_pz_py_nx_type),
+                dest=self._get_diagonally_shifted_coord_rank(coord_shift=[1, 1, -1]),
+            )
+        )
+        self.comm_requests.append(
+            self.mpi_construct.grid.Irecv(
+                (local_field, self.recv_from_nz_ny_px_type),
+                source=self._get_diagonally_shifted_coord_rank(coord_shift=[-1, -1, 1]),
+            )
+        )
+        # Comm. along -Z, -Y, +X: send to (-1, -1, +1) with recv from (+1, +1, -1) block
+        self.comm_requests.append(
+            self.mpi_construct.grid.Isend(
+                (local_field, self.send_to_nz_ny_px_type),
+                dest=self._get_diagonally_shifted_coord_rank(coord_shift=[-1, -1, 1]),
+            )
+        )
+        self.comm_requests.append(
+            self.mpi_construct.grid.Irecv(
+                (local_field, self.recv_from_pz_py_nx_type),
+                source=self._get_diagonally_shifted_coord_rank(coord_shift=[1, 1, -1]),
+            )
+        )
+        # Comm. along -Z, +Y, -X: send to (-1, +1, -1) with recv from (+1, -1, +1) block
+        self.comm_requests.append(
+            self.mpi_construct.grid.Isend(
+                (local_field, self.send_to_nz_py_nx_type),
+                dest=self._get_diagonally_shifted_coord_rank(coord_shift=[-1, 1, -1]),
+            )
+        )
+        self.comm_requests.append(
+            self.mpi_construct.grid.Irecv(
+                (local_field, self.recv_from_pz_ny_px_type),
+                source=self._get_diagonally_shifted_coord_rank(coord_shift=[1, -1, 1]),
+            )
+        )
+        # Comm. along +Z, -Y, -X: send to (+1, -1, -1) with recv from (-1, +1, +1) block
+        self.comm_requests.append(
+            self.mpi_construct.grid.Isend(
+                (local_field, self.send_to_pz_ny_nx_type),
+                dest=self._get_diagonally_shifted_coord_rank(coord_shift=[1, -1, -1]),
+            )
+        )
+        self.comm_requests.append(
+            self.mpi_construct.grid.Irecv(
+                (local_field, self.recv_from_nz_py_px_type),
+                source=self._get_diagonally_shifted_coord_rank(coord_shift=[-1, 1, 1]),
+            )
+        )
+        # Comm. along -Z, -Y, -X: send to (-1, -1, -1) with recv from (+1, +1, +1) block
+        self.comm_requests.append(
+            self.mpi_construct.grid.Isend(
+                (local_field, self.send_to_nz_ny_nx_type),
+                dest=self._get_diagonally_shifted_coord_rank(coord_shift=[-1, -1, -1]),
+            )
+        )
+        self.comm_requests.append(
+            self.mpi_construct.grid.Irecv(
+                (local_field, self.recv_from_pz_py_px_type),
+                source=self._get_diagonally_shifted_coord_rank(coord_shift=[1, 1, 1]),
+            )
+        )
+
+    def exchange_scalar_field_full_init(self, local_field):
+        """
+        Exchange scalar field ghost data including all faces, edges and vertices between
+        neighbors.
+        """
+        self.exchange_scalar_field_faces_init(local_field)
+        self.exchange_scalar_field_edges_init(local_field)
+        self.exchange_scalar_field_vertices_init(local_field)
 
     def exchange_vector_field_init(self, local_vector_field):
         self.exchange_scalar_field_init(

--- a/tests/test_utils/test_mpi_utils_2d.py
+++ b/tests/test_utils/test_mpi_utils_2d.py
@@ -82,13 +82,13 @@ def test_mpi_field_gather_scatter(
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("rank_distribution", [(1, 0), (0, 1), (2, 2)])
 @pytest.mark.parametrize("aspect_ratio", [(1, 1), (1, 2), (2, 1)])
-@pytest.mark.parametrize("halo_mode", [True, False])
+@pytest.mark.parametrize("full_exchange", [True, False])
 def test_mpi_ghost_communication(
     ghost_size,
     precision,
     rank_distribution,
     aspect_ratio,
-    halo_mode,
+    full_exchange,
 ):
     n_values = 32
     real_t = get_real_t(precision)
@@ -103,7 +103,7 @@ def test_mpi_ghost_communication(
     mpi_ghost_exchange_communicator = MPIGhostCommunicator2D(
         ghost_size=ghost_size,
         mpi_construct=mpi_construct,
-        halo_mode=halo_mode,
+        full_exchange=full_exchange,
     )
     # Set internal field to manufactured values
     np.random.seed(0)
@@ -166,7 +166,7 @@ def test_mpi_ghost_communication(
         local_vector_field[:, ghost_size:-ghost_size, 0:ghost_size],
     )
 
-    if halo_mode:
+    if full_exchange:
         # Check bottom left (ghost cell) == top right (inner cell)
         np.testing.assert_allclose(
             local_scalar_field[:ghost_size, :ghost_size],  # bottom left (ghost cell)

--- a/tests/test_utils/test_mpi_utils_2d.py
+++ b/tests/test_utils/test_mpi_utils_2d.py
@@ -12,7 +12,7 @@ from mpi4py import MPI
 
 
 @pytest.mark.mpi(group="MPI_utils", min_size=4)
-@pytest.mark.parametrize("ghost_size", [1, 2, 3])
+@pytest.mark.parametrize("ghost_size", [1, 2])
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("rank_distribution", [(1, 0), (0, 1)])
 @pytest.mark.parametrize("aspect_ratio", [(1, 1), (1, 2), (2, 1)])
@@ -20,7 +20,7 @@ from mpi4py import MPI
 def test_mpi_field_gather_scatter(
     ghost_size, precision, rank_distribution, aspect_ratio, master_rank
 ):
-    n_values = 32
+    n_values = 8
     real_t = get_real_t(precision)
     mpi_construct = MPIConstruct2D(
         grid_size_y=n_values * aspect_ratio[0],
@@ -79,7 +79,7 @@ def test_mpi_field_gather_scatter(
 
 
 @pytest.mark.mpi(group="MPI_utils", min_size=4)
-@pytest.mark.parametrize("ghost_size", [1, 2, 3])
+@pytest.mark.parametrize("ghost_size", [1, 2])
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize("rank_distribution", [(1, 0), (0, 1), (2, 2)])
 @pytest.mark.parametrize("aspect_ratio", [(1, 1), (1, 2), (2, 1)])
@@ -91,7 +91,7 @@ def test_mpi_ghost_communication(
     aspect_ratio,
     full_exchange,
 ):
-    n_values = 32
+    n_values = 8
     real_t = get_real_t(precision)
     mpi_construct = MPIConstruct2D(
         grid_size_y=n_values * aspect_ratio[0],
@@ -230,7 +230,7 @@ def test_mpi_ghost_communication(
 @pytest.mark.parametrize("aspect_ratio", [(1, 1), (1, 2), (2, 1)])
 def test_mpi_lagrangian_field_map(precision, rank_distribution, aspect_ratio):
     # Eulerian grid stuff
-    n_values = 32
+    n_values = 8
     real_t = get_real_t(precision)
     grid_size_y = n_values * aspect_ratio[0]
     grid_size_x = n_values * aspect_ratio[1]
@@ -310,7 +310,7 @@ def test_mpi_lagrangian_field_gather_scatter(
     precision, rank_distribution, aspect_ratio
 ):
     # Eulerian grid stuff
-    n_values = 32
+    n_values = 8
     real_t = get_real_t(precision)
     grid_size_y = n_values * aspect_ratio[0]
     grid_size_x = n_values * aspect_ratio[1]

--- a/tests/test_utils/test_mpi_utils_3d.py
+++ b/tests/test_utils/test_mpi_utils_3d.py
@@ -12,7 +12,7 @@ from mpi4py import MPI
 
 
 @pytest.mark.mpi(group="MPI_utils", min_size=4)
-@pytest.mark.parametrize("ghost_size", [1, 2, 3])
+@pytest.mark.parametrize("ghost_size", [1, 2])
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize(
     "rank_distribution",
@@ -26,7 +26,7 @@ from mpi4py import MPI
 def test_mpi_field_gather_scatter(
     ghost_size, precision, rank_distribution, aspect_ratio, master_rank
 ):
-    n_values = 32
+    n_values = 8
     real_t = get_real_t(precision)
     mpi_construct = MPIConstruct3D(
         grid_size_z=n_values * aspect_ratio[0],
@@ -94,7 +94,7 @@ def test_mpi_field_gather_scatter(
 
 
 @pytest.mark.mpi(group="MPI_utils", min_size=4)
-@pytest.mark.parametrize("ghost_size", [1, 2, 3])
+@pytest.mark.parametrize("ghost_size", [1, 2])
 @pytest.mark.parametrize("precision", ["single", "double"])
 @pytest.mark.parametrize(
     "rank_distribution",
@@ -108,7 +108,7 @@ def test_mpi_field_gather_scatter(
 def test_mpi_ghost_communication(
     ghost_size, precision, rank_distribution, aspect_ratio, full_exchange
 ):
-    n_values = 32
+    n_values = 8
     real_t = get_real_t(precision)
     mpi_construct = MPIConstruct3D(
         grid_size_z=n_values * aspect_ratio[0],
@@ -794,7 +794,7 @@ def test_mpi_ghost_communication(
 )
 def test_mpi_lagrangian_field_map(precision, rank_distribution, aspect_ratio):
     # Eulerian grid stuff
-    n_values = 32
+    n_values = 8
     real_t = get_real_t(precision)
     grid_size_z = n_values * aspect_ratio[0]
     grid_size_y = n_values * aspect_ratio[1]
@@ -889,7 +889,7 @@ def test_mpi_lagrangian_field_gather_scatter(
     precision, rank_distribution, aspect_ratio
 ):
     # Eulerian grid stuff
-    n_values = 32
+    n_values = 8
     real_t = get_real_t(precision)
     grid_size_z = n_values * aspect_ratio[0]
     grid_size_y = n_values * aspect_ratio[1]

--- a/tests/test_utils/test_mpi_utils_3d.py
+++ b/tests/test_utils/test_mpi_utils_3d.py
@@ -780,3 +780,216 @@ def test_mpi_ghost_communication(
                 -ghost_size : local_vector_field.shape[3],
             ],
         )
+
+
+@pytest.mark.mpi(group="MPI_utils", min_size=4)
+@pytest.mark.parametrize("precision", ["single", "double"])
+@pytest.mark.parametrize(
+    "rank_distribution",
+    [(0, 1, 1), (1, 0, 1), (1, 1, 0), (1, 0, 0), (0, 1, 0), (0, 0, 1)],
+)
+@pytest.mark.parametrize(
+    "aspect_ratio",
+    [(1, 1, 1), (1, 1, 2), (1, 2, 1), (2, 1, 1), (1, 2, 2), (2, 1, 2), (2, 2, 1)],
+)
+def test_mpi_lagrangian_field_map(precision, rank_distribution, aspect_ratio):
+    # Eulerian grid stuff
+    n_values = 32
+    real_t = get_real_t(precision)
+    grid_size_z = n_values * aspect_ratio[0]
+    grid_size_y = n_values * aspect_ratio[1]
+    grid_size_x = n_values * aspect_ratio[2]
+    mpi_construct = MPIConstruct3D(
+        grid_size_z=grid_size_z,
+        grid_size_y=grid_size_y,
+        grid_size_x=grid_size_x,
+        real_t=real_t,
+        rank_distribution=rank_distribution,
+    )
+    x_range = real_t(1.0)
+    y_range = x_range * grid_size_y / grid_size_x
+    z_range = x_range * grid_size_z / grid_size_x
+    eul_grid_dx = real_t(x_range / grid_size_x)
+    eul_grid_coord_shift = real_t(eul_grid_dx / 2.0)
+
+    # Lagrangian grid stuff
+    # Define a master rank that "owns" the lagrangian grid
+    # It serves as the central process where points are gathered to / scattered from
+    master_rank = 0
+    mpi_lagrangian_field_communicator = MPILagrangianFieldCommunicator3D(
+        eul_grid_dx=eul_grid_dx,
+        eul_grid_coord_shift=eul_grid_coord_shift,
+        mpi_construct=mpi_construct,
+        master_rank=master_rank,
+        real_t=real_t,
+    )
+
+    # Initialize fields for testing
+    # Sample a diagonal line across domain
+    global_lagrangian_positions = np.tile(
+        np.arange(
+            2 * eul_grid_coord_shift,
+            x_range - 2 * eul_grid_coord_shift,
+            eul_grid_dx / 2.0,
+        ),
+        [mpi_lagrangian_field_communicator.grid_dim, 1],
+    ).astype(real_t)
+    # rescale to spread them across the scaled eulerian domain
+    global_lagrangian_positions[VectorField.x_axis_idx(), :] *= x_range
+    global_lagrangian_positions[VectorField.y_axis_idx(), :] *= y_range
+    global_lagrangian_positions[VectorField.z_axis_idx(), :] *= z_range
+
+    # Map the lagrangian nodes to respective ranks
+    mpi_lagrangian_field_communicator.map_lagrangian_nodes_based_on_position(
+        global_lag_positions=global_lagrangian_positions
+    )
+    # Get locally mapped lagrangian grids
+    rank_address = mpi_lagrangian_field_communicator.rank_address
+    idx = np.where(rank_address == mpi_construct.rank)[0]
+    local_lagrangian_positions = global_lagrangian_positions[:, idx]
+
+    # Define local bounds
+    local_grid_size = mpi_construct.local_grid_size
+    substart_idx = mpi_construct.grid.coords * local_grid_size
+    subend_idx = substart_idx + local_grid_size
+    substart_z, substart_y, substart_x = (
+        substart_idx * eul_grid_dx + eul_grid_coord_shift
+    )
+    subend_z, subend_y, subend_x = subend_idx * eul_grid_dx + eul_grid_coord_shift
+
+    # Check locally mapped lagrangian nodes are within local eulerian grid bounds
+    assert np.all(
+        local_lagrangian_positions[VectorField.x_axis_idx(), :] >= substart_x
+    ) & np.all(local_lagrangian_positions[VectorField.x_axis_idx(), :] < subend_x)
+    assert np.all(
+        local_lagrangian_positions[VectorField.y_axis_idx(), :] >= substart_y
+    ) & np.all(local_lagrangian_positions[VectorField.y_axis_idx(), :] < subend_y)
+    assert np.all(
+        local_lagrangian_positions[VectorField.z_axis_idx(), :] >= substart_z
+    ) & np.all(local_lagrangian_positions[VectorField.z_axis_idx(), :] < subend_z)
+
+    # Ensure that we taken all lagrangian points into account
+    local_num_lag_nodes = local_lagrangian_positions.shape[1]
+    assert local_num_lag_nodes == mpi_lagrangian_field_communicator.local_num_lag_nodes
+    global_num_lag_nodes = mpi_construct.grid.allreduce(local_num_lag_nodes, op=MPI.SUM)
+    assert global_num_lag_nodes == global_lagrangian_positions.shape[1]
+
+
+@pytest.mark.mpi(group="MPI_utils", min_size=4)
+@pytest.mark.parametrize("precision", ["single", "double"])
+@pytest.mark.parametrize(
+    "rank_distribution",
+    [(0, 1, 1), (1, 0, 1), (1, 1, 0), (1, 0, 0), (0, 1, 0), (0, 0, 1)],
+)
+@pytest.mark.parametrize(
+    "aspect_ratio",
+    [(1, 1, 1), (1, 1, 2), (1, 2, 1), (2, 1, 1), (1, 2, 2), (2, 1, 2), (2, 2, 1)],
+)
+def test_mpi_lagrangian_field_gather_scatter(
+    precision, rank_distribution, aspect_ratio
+):
+    # Eulerian grid stuff
+    n_values = 32
+    real_t = get_real_t(precision)
+    grid_size_z = n_values * aspect_ratio[0]
+    grid_size_y = n_values * aspect_ratio[1]
+    grid_size_x = n_values * aspect_ratio[2]
+    mpi_construct = MPIConstruct3D(
+        grid_size_z=grid_size_z,
+        grid_size_y=grid_size_y,
+        grid_size_x=grid_size_x,
+        real_t=real_t,
+        rank_distribution=rank_distribution,
+    )
+    x_range = real_t(1.0)
+    y_range = x_range * grid_size_y / grid_size_x
+    z_range = x_range * grid_size_z / grid_size_x
+    eul_grid_dx = real_t(x_range / grid_size_x)
+    eul_grid_coord_shift = real_t(eul_grid_dx / 2.0)
+
+    # Lagrangian grid stuff
+    # Define a master rank that "owns" the lagrangian grid
+    # It serves as the central process where points are gathered to / scattered from
+    master_rank = 0
+    mpi_lagrangian_field_communicator = MPILagrangianFieldCommunicator3D(
+        eul_grid_dx=eul_grid_dx,
+        eul_grid_coord_shift=eul_grid_coord_shift,
+        mpi_construct=mpi_construct,
+        master_rank=master_rank,
+        real_t=real_t,
+    )
+
+    # Initialize fields for testing
+    global_num_lag_nodes = 100
+    # generate random lagrangian nodes within eulerian bounds
+    global_lagrangian_positions = np.zeros(
+        (mpi_lagrangian_field_communicator.grid_dim, global_num_lag_nodes)
+    ).astype(real_t)
+    global_lagrangian_positions[VectorField.x_axis_idx(), :] = np.random.uniform(
+        2 * eul_grid_coord_shift,
+        x_range - 2 * eul_grid_coord_shift,
+        global_num_lag_nodes,
+    )
+    global_lagrangian_positions[VectorField.y_axis_idx(), :] = np.random.uniform(
+        2 * eul_grid_coord_shift,
+        y_range - 2 * eul_grid_coord_shift,
+        global_num_lag_nodes,
+    )
+    global_lagrangian_positions[VectorField.z_axis_idx(), :] = np.random.uniform(
+        2 * eul_grid_coord_shift,
+        z_range - 2 * eul_grid_coord_shift,
+        global_num_lag_nodes,
+    )
+    # generate random velocities at these lagrangian nodes
+    global_lagrangian_velocities = np.random.rand(
+        mpi_lagrangian_field_communicator.grid_dim, global_num_lag_nodes
+    ).astype(real_t)
+    ref_global_lagrangian_positions = global_lagrangian_positions.copy()
+    ref_global_lagrangian_velocities = global_lagrangian_velocities.copy()
+
+    # Map the lagrangian nodes to respective ranks
+    mpi_lagrangian_field_communicator.map_lagrangian_nodes_based_on_position(
+        global_lag_positions=global_lagrangian_positions
+    )
+
+    local_lagrangian_positions = np.zeros(
+        (
+            mpi_lagrangian_field_communicator.grid_dim,
+            mpi_lagrangian_field_communicator.local_num_lag_nodes,
+        )
+    ).astype(real_t)
+    local_lagrangian_velocities = np.zeros_like(local_lagrangian_positions)
+
+    # scatter global field to other ranks
+    mpi_lagrangian_field_communicator.scatter_global_field(
+        local_lag_field=local_lagrangian_positions,
+        global_lag_field=ref_global_lagrangian_positions,
+    )
+    mpi_lagrangian_field_communicator.scatter_global_field(
+        local_lag_field=local_lagrangian_velocities,
+        global_lag_field=ref_global_lagrangian_velocities,
+    )
+
+    # randomise global fields after scatter
+    global_lagrangian_positions[...] = np.random.rand(
+        mpi_lagrangian_field_communicator.grid_dim, global_num_lag_nodes
+    ).astype(real_t)
+    global_lagrangian_velocities[...] = np.random.rand(
+        mpi_lagrangian_field_communicator.grid_dim, global_num_lag_nodes
+    ).astype(real_t)
+    # reconstruct global field from local ranks
+    mpi_lagrangian_field_communicator.gather_local_field(
+        global_lag_field=global_lagrangian_positions,
+        local_lag_field=local_lagrangian_positions,
+    )
+    mpi_lagrangian_field_communicator.gather_local_field(
+        global_lag_field=global_lagrangian_velocities,
+        local_lag_field=local_lagrangian_velocities,
+    )
+    if mpi_construct.rank == mpi_lagrangian_field_communicator.master_rank:
+        np.testing.assert_allclose(
+            ref_global_lagrangian_positions, global_lagrangian_positions
+        )
+        np.testing.assert_allclose(
+            ref_global_lagrangian_velocities, global_lagrangian_velocities
+        )


### PR DESCRIPTION
Fixes #160 

The code is a bit long, mainly because we are doing non-blocking communications for ghosting, and so we need to take care of the different parts of the ghost zones separately (i.e. corners). One can of course make blocking calls as shown [here](https://iamsorush.com/posts/cpp-mpi-halo-exchange/), which then would reduce the need to take care of different parts separately and rely on the order of communication to transfer the corners automatically.

In any case, this corner ghosting is needed when we have Eulerian-to-Lagrangian grid interpolation, since the Lagrangian grid might come close to the corner regions of the local domain, thus needed the ghosted corner cells. The implementation seems to work since (1) it passes all the update tests that includes checking corner cells and (2) Eulerian-to-Lagrangian interpolation now works (I will push the implementation in a different PR when addressing #157 )