### PR TITLE
Flow past sphere

### DIFF
--- a/examples/3d_examples/FlowPastSphereCase/flow_past_sphere_case.py
+++ b/examples/3d_examples/FlowPastSphereCase/flow_past_sphere_case.py
@@ -1,0 +1,246 @@
+import click
+import elastica as ea
+import numpy as np
+import sopht_mpi.simulator as sps
+import sopht.utils as spu
+from sopht_mpi.utils import logger
+from sopht_mpi.utils.mpi_io import MPIIO
+from mpi4py import MPI
+from typing import Optional
+from sopht_mpi.utils.mpi_utils_2d import MPIPlotter2D
+
+
+def flow_past_sphere_case(
+    nondim_time: float,
+    grid_size: tuple[int, int, int],
+    reynolds: float = 100.0,
+    coupling_stiffness: float = -6e5 / 4,
+    coupling_damping: float = -3.5e2 / 4,
+    rank_distribution: Optional[tuple[int, int, int]] = None,
+    precision: str = "single",
+    save_flow_data: bool = False,
+) -> None:
+    """
+    This example considers the case of flow past a sphere in 3D.
+    """
+    grid_size_z, grid_size_y, grid_size_x = grid_size
+    real_t = spu.get_real_t(precision)
+    x_axis_idx: int = spu.VectorField.x_axis_idx()
+    y_axis_idx = spu.VectorField.y_axis_idx()
+    z_axis_idx = spu.VectorField.z_axis_idx()
+    x_range = 1.0
+    far_field_velocity = 1.0
+    sphere_diameter = 0.4 * min(grid_size_z, grid_size_y) / grid_size_x * x_range
+    nu = far_field_velocity * sphere_diameter / reynolds
+    flow_sim = sps.UnboundedFlowSimulator3D(
+        grid_size=grid_size,
+        x_range=x_range,
+        kinematic_viscosity=nu,
+        real_t=real_t,
+        rank_distribution=rank_distribution,
+        flow_type="navier_stokes_with_forcing",
+        with_free_stream_flow=True,
+        time=0.0,
+    )
+    rho_f = 1.0
+    sphere_projected_area = 0.25 * np.pi * sphere_diameter**2
+    drag_force_scale = 0.5 * rho_f * far_field_velocity**2 * sphere_projected_area
+
+    # Initialize velocity = c in X direction
+    velocity_free_stream = np.array([far_field_velocity, 0.0, 0.0])
+
+    # Initialize fixed sphere (elastica rigid body)
+    x_cm = 0.25 * flow_sim.x_range
+    y_cm = 0.5 * flow_sim.y_range
+    z_cm = 0.5 * flow_sim.z_range
+    sphere_com = np.array([x_cm, y_cm, z_cm])
+    density = 1e3
+    sphere = ea.Sphere(
+        center=sphere_com, base_radius=(sphere_diameter / 2.0), density=density
+    )
+    # Since the sphere is fixed, we don't add it to pyelastica simulator,
+    # and directly use it for setting up the flow interactor.
+    # ==================FLOW-BODY COMMUNICATOR SETUP START======
+    num_forcing_points_along_equator = int(
+        1.875 * sphere_diameter / x_range * grid_size_x
+    )
+    master_rank = 0  # define master rank for lagrangian related grids
+    sphere_flow_interactor = sps.RigidBodyFlowInteractionMPI(
+        mpi_construct=flow_sim.mpi_construct,
+        mpi_ghost_exchange_communicator=flow_sim.mpi_ghost_exchange_communicator,
+        rigid_body=sphere,
+        eul_grid_forcing_field=flow_sim.eul_grid_forcing_field,
+        eul_grid_velocity_field=flow_sim.velocity_field,
+        virtual_boundary_stiffness_coeff=coupling_stiffness,
+        virtual_boundary_damping_coeff=coupling_damping,
+        dx=flow_sim.dx,
+        grid_dim=flow_sim.grid_dim,
+        real_t=real_t,
+        moving_body=False,  # initialize as non-moving boundary
+        master_rank=master_rank,
+        forcing_grid_cls=sps.SphereForcingGrid,
+        num_forcing_points_along_equator=num_forcing_points_along_equator,
+    )
+    # ==================FLOW-BODY COMMUNICATOR SETUP END======
+
+    if save_flow_data:
+        # setup IO
+        # TODO internalise this in flow simulator as dump_fields
+        origin_x = flow_sim.mpi_construct.grid.allreduce(
+            flow_sim.position_field[
+                x_axis_idx,
+                flow_sim.ghost_size : -flow_sim.ghost_size,
+                flow_sim.ghost_size : -flow_sim.ghost_size,
+                flow_sim.ghost_size : -flow_sim.ghost_size,
+            ].min(),
+            op=MPI.MIN,
+        )
+        origin_y = flow_sim.mpi_construct.grid.allreduce(
+            flow_sim.position_field[
+                y_axis_idx,
+                flow_sim.ghost_size : -flow_sim.ghost_size,
+                flow_sim.ghost_size : -flow_sim.ghost_size,
+                flow_sim.ghost_size : -flow_sim.ghost_size,
+            ].min(),
+            op=MPI.MIN,
+        )
+        origin_z = flow_sim.mpi_construct.grid.allreduce(
+            flow_sim.position_field[
+                z_axis_idx,
+                flow_sim.ghost_size : -flow_sim.ghost_size,
+                flow_sim.ghost_size : -flow_sim.ghost_size,
+                flow_sim.ghost_size : -flow_sim.ghost_size,
+            ].min(),
+            op=MPI.MIN,
+        )
+        io_origin = np.array([origin_z, origin_y, origin_x])
+        io_dx = flow_sim.dx * np.ones(flow_sim.grid_dim)
+        io_grid_size = np.array([grid_size_z, grid_size_y, grid_size_x])
+        io = MPIIO(mpi_construct=flow_sim.mpi_construct, real_dtype=real_t)
+        io.define_eulerian_grid(
+            origin=io_origin,
+            dx=io_dx,
+            grid_size=io_grid_size,
+            ghost_size=flow_sim.ghost_size,
+        )
+        io.add_as_eulerian_fields_for_io(
+            vorticity=flow_sim.vorticity_field, velocity=flow_sim.velocity_field
+        )
+        # Initialize sphere IO
+        sphere_io = MPIIO(mpi_construct=flow_sim.mpi_construct, real_dtype=real_t)
+        # Add vector field on lagrangian grid
+        sphere_io.add_as_lagrangian_fields_for_io(
+            lagrangian_grid=sphere_flow_interactor.forcing_grid.position_field,
+            lagrangian_grid_master_rank=sphere_flow_interactor.master_rank,
+            lagrangian_grid_name="sphere",
+            vector_3d=sphere_flow_interactor.global_lag_grid_forcing_field,
+        )
+
+    timescale = sphere_diameter / far_field_velocity
+    t_end_hat = nondim_time  # non-dimensional end time
+    t_end = t_end_hat * timescale  # dimensional end time
+    foto_timer = 0.0
+    foto_timer_limit = timescale / 10
+
+    time = []
+    drag_coeffs = []
+
+    # iterate
+    while flow_sim.time < t_end:
+        # Save data
+        if foto_timer > foto_timer_limit or foto_timer == 0:
+            foto_timer = 0.0
+            # calculate drag
+            drag_coeff = 0.0
+            if flow_sim.mpi_construct.rank == master_rank:
+                drag_force = np.fabs(
+                    np.sum(
+                        sphere_flow_interactor.global_lag_grid_forcing_field[
+                            x_axis_idx, ...
+                        ]
+                    )
+                )
+                drag_coeff = drag_force / drag_force_scale
+                time.append(flow_sim.time)
+                drag_coeffs.append(drag_coeff)
+
+            if save_flow_data:
+                io.save(
+                    h5_file_name="sopht_"
+                    + str("%0.4d" % (flow_sim.time * 100))
+                    + ".h5",
+                    time=flow_sim.time,
+                )
+                sphere_io.save(
+                    h5_file_name="sphere_"
+                    + str("%0.4d" % (flow_sim.time * 100))
+                    + ".h5",
+                    time=flow_sim.time,
+                )
+
+            # Log some diagnostics
+            logger.info(
+                f"time: {flow_sim.time:.2f} ({(flow_sim.time/t_end*100):2.1f}%), "
+                f"max_vort: {flow_sim.get_max_vorticity():.4f}, "
+                f"drag coeff: {drag_coeff:.4f}, "
+                f"vort divg. L2 norm: {flow_sim.get_vorticity_divergence_l2_norm():.4f} "
+                "grid deviation L2 error: "
+                f"{sphere_flow_interactor.get_grid_deviation_error_l2_norm():.6f}"
+            )
+
+        dt = flow_sim.compute_stable_timestep(dt_prefac=0.5)
+
+        # compute flow forcing and timestep forcing
+        sphere_flow_interactor.time_step(dt=dt)
+        sphere_flow_interactor()
+
+        flow_sim.time_step(dt=dt, free_stream_velocity=velocity_free_stream)
+
+        # update timers
+        foto_timer += dt
+
+    # Initialize mpi-supported plotter
+    mpi_plotter = MPIPlotter2D(
+        flow_sim.mpi_construct,
+        flow_sim.ghost_size,
+        title=f"Vorticity, time: {flow_sim.time / timescale:.2f}",
+        master_rank=sphere_flow_interactor.master_rank,
+    )
+    mpi_plotter.ax.set_aspect(aspect="auto")
+    mpi_plotter.plot(np.array(time), np.array(drag_coeffs), label="numerical")
+    mpi_plotter.ax.set_xlabel("Time")
+    mpi_plotter.ax.set_ylabel("Drag coefficient")
+    mpi_plotter.savefig("drag_coeff_vs_time.png")
+
+    if flow_sim.mpi_construct.rank == master_rank:
+        np.savetxt(
+            "drag_vs_time.csv",
+            np.c_[np.array(time), np.array(drag_coeffs)],
+            delimiter=",",
+            header="time, drag_coeff",
+        )
+
+        if save_flow_data:
+            spu.make_dir_and_transfer_h5_data(dir_name="flow_data_h5")
+
+
+if __name__ == "__main__":
+
+    @click.command()
+    @click.option("--nx", default=128, help="Number of grid points in x direction.")
+    @click.option("--reynolds", default=100.0, help="Reynolds number of flow.")
+    def simulate_parallelised_flow_past_sphere(nx: int, reynolds: float) -> None:
+        ny = nx // 2
+        nz = nx // 2
+        # in order Z, Y, X
+        grid_size = (nz, ny, nx)
+        logger.info(f"Grid size: {grid_size}")
+        logger.info(f"Flow Reynolds number: {reynolds}")
+        flow_past_sphere_case(
+            nondim_time=10.0,
+            grid_size=grid_size,
+            reynolds=reynolds,
+            save_flow_data=True,
+        )
+
+    simulate_parallelised_flow_past_sphere()

--- a/sopht_mpi/simulator/flow/flow_simulators_mpi_3d.py
+++ b/sopht_mpi/simulator/flow/flow_simulators_mpi_3d.py
@@ -455,7 +455,10 @@ class UnboundedFlowSimulator3D:
         )
         # Perform the expression below in an MPI context.
         # vorticity_divg_l2_norm = np.linalg.norm(divergence_field) * self.dx**1.5
-        local_vorticity_divg_l2_norm_sq = np.linalg.norm(divergence_field) ** 2
+        gs = self.ghost_size
+        local_vorticity_divg_l2_norm_sq = (
+            np.linalg.norm(divergence_field[gs:-gs, gs:-gs, gs:-gs]) ** 2
+        )
         vorticity_divg_l2_norm_sq = self.mpi_construct.grid.allreduce(
             local_vorticity_divg_l2_norm_sq, op=MPI.SUM
         )

--- a/sopht_mpi/simulator/immersed_body/__init__.py
+++ b/sopht_mpi/simulator/immersed_body/__init__.py
@@ -1,5 +1,10 @@
-from sopht_mpi.simulator.immersed_body.immersed_body_flow_interaction_mpi import *
-from sopht_mpi.simulator.immersed_body.immersed_body_forcing_grid import *
+from sopht_mpi.simulator.immersed_body.immersed_body_flow_interaction_mpi import (
+    ImmersedBodyFlowInteractionMPI,
+)
+from sopht_mpi.simulator.immersed_body.immersed_body_forcing_grid import (
+    ImmersedBodyForcingGrid,
+    EmptyForcingGrid,
+)
 from sopht_mpi.simulator.immersed_body.rigid_body import *
 from sopht_mpi.simulator.immersed_body.cosserat_rod import *
 from sopht_mpi.simulator.immersed_body.flow_forces import *

--- a/sopht_mpi/simulator/immersed_body/immersed_body_flow_interaction_mpi.py
+++ b/sopht_mpi/simulator/immersed_body/immersed_body_flow_interaction_mpi.py
@@ -1,4 +1,3 @@
-__all__ = ["ImmersedBodyFlowInteractionMPI"]
 import numpy as np
 from sopht_mpi.numeric.immersed_boundary_ops import VirtualBoundaryForcingMPI
 from sopht_mpi.simulator.immersed_body.immersed_body_forcing_grid import (

--- a/sopht_mpi/simulator/immersed_body/immersed_body_forcing_grid.py
+++ b/sopht_mpi/simulator/immersed_body/immersed_body_forcing_grid.py
@@ -1,4 +1,3 @@
-__all__ = ["ImmersedBodyForcingGrid", "EmptyForcingGrid"]
 from abc import ABC, abstractmethod
 import numpy as np
 from sopht_mpi.utils import logger

--- a/sopht_mpi/simulator/immersed_body/rigid_body/__init__.py
+++ b/sopht_mpi/simulator/immersed_body/rigid_body/__init__.py
@@ -1,2 +1,9 @@
-from sopht_mpi.simulator.immersed_body.rigid_body.rigid_body_forcing_grids import *
-from sopht_mpi.simulator.immersed_body.rigid_body.rigid_body_flow_interaction_mpi import *
+from sopht_mpi.simulator.immersed_body.rigid_body.rigid_body_forcing_grids import (
+    TwoDimensionalCylinderForcingGrid,
+    CircularCylinderForcingGrid,
+    ThreeDimensionalRigidBodyForcingGrid,
+    SphereForcingGrid,
+)
+from sopht_mpi.simulator.immersed_body.rigid_body.rigid_body_flow_interaction_mpi import (
+    RigidBodyFlowInteractionMPI,
+)

--- a/sopht_mpi/simulator/immersed_body/rigid_body/rigid_body_flow_interaction_mpi.py
+++ b/sopht_mpi/simulator/immersed_body/rigid_body/rigid_body_flow_interaction_mpi.py
@@ -1,4 +1,3 @@
-__all__ = ["RigidBodyFlowInteractionMPI"]
 from elastica import RigidBodyBase
 import numpy as np
 from sopht_mpi.simulator.immersed_body import (

--- a/sopht_mpi/simulator/immersed_body/rigid_body/rigid_body_forcing_grids.py
+++ b/sopht_mpi/simulator/immersed_body/rigid_body/rigid_body_forcing_grids.py
@@ -1,11 +1,8 @@
-__all__ = [
-    "TwoDimensionalCylinderForcingGrid",
-    "CircularCylinderForcingGrid",
-]
-
-from elastica import Cylinder
+import elastica as ea
+from elastica._linalg import _batch_cross
 import numpy as np
 from sopht_mpi.simulator.immersed_body import ImmersedBodyForcingGrid
+from typing import Union
 
 
 class TwoDimensionalCylinderForcingGrid(ImmersedBodyForcingGrid):
@@ -17,7 +14,7 @@ class TwoDimensionalCylinderForcingGrid(ImmersedBodyForcingGrid):
     def __init__(
         self,
         grid_dim,
-        rigid_body: type(Cylinder),
+        rigid_body: ea.Cylinder,
     ):
         if grid_dim != 2:
             raise ValueError(
@@ -91,7 +88,7 @@ class CircularCylinderForcingGrid(TwoDimensionalCylinderForcingGrid):
     def __init__(
         self,
         grid_dim,
-        rigid_body: type(Cylinder),
+        rigid_body: ea.Cylinder,
         num_forcing_points,
         real_t=np.float64,
     ):
@@ -123,3 +120,161 @@ class CircularCylinderForcingGrid(TwoDimensionalCylinderForcingGrid):
         """Get the maximum Lagrangian grid spacing"""
         # ds = radius * dtheta
         return self.cylinder.radius * (2.0 * np.pi / self.num_lag_nodes)
+
+
+SupportedRigidBody3D = Union[ea.Cylinder, ea.Sphere]
+
+
+class ThreeDimensionalRigidBodyForcingGrid(ImmersedBodyForcingGrid):
+    """Class for forcing grid of a 3D rigid body with cross-section."""
+
+    # Will be set in derived classes
+    # num_lag_nodes: int = NotImplementedError
+
+    def __init__(self, grid_dim: int, rigid_body: SupportedRigidBody3D) -> None:
+        if grid_dim != 3:
+            raise ValueError(
+                "Invalid grid dimensions. 3D Rigid body forcing grid is only "
+                "defined for grid_dim=3"
+            )
+        self.rigid_body = rigid_body
+        super().__init__(grid_dim)
+        self.local_frame_relative_position_field = np.zeros_like(self.position_field)
+        self.global_frame_relative_position_field = np.zeros_like(self.position_field)
+
+    def compute_lag_grid_position_field(self) -> None:
+        """Computes location of forcing grid for the rigid body boundary"""
+        self.global_frame_relative_position_field[...] = np.dot(
+            self.rigid_body.director_collection[:, :, 0].T,
+            self.local_frame_relative_position_field,
+        )
+        self.position_field[...] = (
+            self.rigid_body.position_collection
+            + self.global_frame_relative_position_field
+        )
+
+    def compute_lag_grid_velocity_field(self) -> None:
+        """Computes velocity of forcing grid points for the rigid body boundary"""
+        global_frame_omega = np.dot(
+            self.rigid_body.director_collection[:, :, 0].T,
+            self.rigid_body.omega_collection,
+        )
+        self.velocity_field[...] = self.rigid_body.velocity_collection + _batch_cross(
+            global_frame_omega * np.ones(self.num_lag_nodes),
+            self.global_frame_relative_position_field,
+        )
+
+    def transfer_forcing_from_grid_to_body(
+        self,
+        body_flow_forces: np.ndarray,
+        body_flow_torques: np.ndarray,
+        lag_grid_forcing_field: np.ndarray,
+    ) -> None:
+        """Transfer forcing from lagrangian forcing grid to the rigid body"""
+        # negative sign due to Newtons third law
+        body_flow_forces[...] = -np.sum(lag_grid_forcing_field, axis=1).reshape(-1, 1)
+
+        # torque from grid forcing
+        body_flow_torques[...] = -np.dot(
+            self.rigid_body.director_collection[:, :, 0],
+            np.sum(
+                _batch_cross(
+                    self.global_frame_relative_position_field, lag_grid_forcing_field
+                ),
+                axis=1,
+            ).reshape(-1, 1),
+        )
+
+    def get_maximum_lagrangian_grid_spacing(self) -> float:
+        """Get the maximum Lagrangian grid spacing"""
+
+
+class SphereForcingGrid(ThreeDimensionalRigidBodyForcingGrid):
+    """Class for forcing grid of a 3D sphere"""
+
+    def __init__(
+        self,
+        grid_dim: int,
+        rigid_body: ea.Sphere,
+        num_forcing_points_along_equator: int,
+        real_t=np.float64,
+    ) -> None:
+        self.num_forcing_points_along_equator = num_forcing_points_along_equator
+        polar_angle_grid = np.linspace(
+            0, np.pi, self.num_forcing_points_along_equator // 2
+        )
+        num_forcing_points_along_latitudes = (
+            np.rint(
+                self.num_forcing_points_along_equator * np.sin(polar_angle_grid)
+            ).astype(int)
+            + 1
+        )
+        self.num_lag_nodes = sum(num_forcing_points_along_latitudes)
+        self.real_t = real_t
+        super().__init__(grid_dim=grid_dim, rigid_body=rigid_body)
+
+        self.initialize_global_frame_relative_position_field(
+            num_forcing_points_along_latitudes, polar_angle_grid
+        )
+
+        # to ensure position/velocity are consistent during initialisation
+        self.compute_lag_grid_position_field()
+        self.compute_lag_grid_velocity_field()
+
+    def initialize_global_frame_relative_position_field(
+        self, num_forcing_points_along_latitudes, polar_angle_grid
+    ):
+        global_frame_relative_position_x = np.array([], dtype=float)
+        global_frame_relative_position_y = np.array([], dtype=float)
+        global_frame_relative_position_z = np.array([], dtype=float)
+        for num_forcing_points_along_latitude, polar_angle in zip(
+            num_forcing_points_along_latitudes, polar_angle_grid
+        ):
+            azimuthal_angle_grid = np.linspace(
+                0.0, 2 * np.pi, num_forcing_points_along_latitude, endpoint=False
+            )
+            global_frame_relative_position_x = np.append(
+                global_frame_relative_position_x,
+                self.rigid_body.radius
+                * np.sin(polar_angle)
+                * np.cos(azimuthal_angle_grid),
+            )
+            global_frame_relative_position_y = np.append(
+                global_frame_relative_position_y,
+                self.rigid_body.radius
+                * np.sin(polar_angle)
+                * np.sin(azimuthal_angle_grid),
+            )
+            global_frame_relative_position_z = np.append(
+                global_frame_relative_position_z,
+                self.rigid_body.radius
+                * np.cos(polar_angle)
+                * np.ones(num_forcing_points_along_latitude),
+            )
+        self.global_frame_relative_position_field[0] = np.array(
+            global_frame_relative_position_x
+        )
+        self.global_frame_relative_position_field[1] = np.array(
+            global_frame_relative_position_y
+        )
+        self.global_frame_relative_position_field[2] = np.array(
+            global_frame_relative_position_z
+        )
+
+    def get_maximum_lagrangian_grid_spacing(self) -> float:
+        """Get the maximum Lagrangian grid spacing"""
+        # ds = radius * dtheta
+        return self.rigid_body.radius * (
+            2 * np.pi / self.num_forcing_points_along_equator
+        )
+
+    def compute_lag_grid_position_field(self) -> None:
+        """Computes location of forcing grid for the rigid sphere.
+        Since this is a sphere, the local frame concept is redundant,
+        and the global relative frame can be directly used.
+        Hence, overloading the method here.
+        """
+        self.position_field[...] = (
+            self.rigid_body.position_collection
+            + self.global_frame_relative_position_field
+        )

--- a/tests/test_simulator/immersed_body/rigid_body/test_rigid_body_forcing_grids.py
+++ b/tests/test_simulator/immersed_body/rigid_body/test_rigid_body_forcing_grids.py
@@ -151,3 +151,173 @@ def test_circular_cylinder_grid_spacing(num_forcing_points):
     cylinder_circumference = 2 * np.pi * cylinder.radius
     correct_max_grid_spacing = cylinder_circumference / num_forcing_points
     assert correct_max_grid_spacing == max_grid_spacing
+
+
+def mock_3d_sphere():
+    """Returns a mock 3D sphere (from elastica) for testing"""
+    sphere_radius = 0.1
+    sphere_com = np.array([1.0, 2.0, 3.0])
+    sphere = ea.Sphere(center=sphere_com, base_radius=sphere_radius, density=1e3)
+    sphere.velocity_collection[...] = 3.0
+    sphere.omega_collection[...] = 4.0
+    return sphere
+
+
+@pytest.mark.parametrize("grid_dim", [2, 3])
+def test_sphere_grid_invalid_dim(grid_dim):
+    sphere = mock_3d_sphere()
+    if grid_dim != 3:
+        with pytest.raises(ValueError) as exc_info:
+            _ = sps.SphereForcingGrid(
+                grid_dim=grid_dim,
+                rigid_body=sphere,
+                num_forcing_points_along_equator=8,
+            )
+        error_msg = (
+            "Invalid grid dimensions. 3D Rigid body forcing grid is only "
+            "defined for grid_dim=3"
+        )
+        assert exc_info.value.args[0] == error_msg
+
+
+@pytest.mark.parametrize("num_forcing_points_along_equator", [8, 16])
+def test_sphere_grid_kinematics(num_forcing_points_along_equator):
+    sphere = mock_3d_sphere()
+    grid_dim = 3
+    sphere_forcing_grid = sps.SphereForcingGrid(
+        grid_dim=grid_dim,
+        rigid_body=sphere,
+        num_forcing_points_along_equator=num_forcing_points_along_equator,
+    )
+    assert sphere_forcing_grid.rigid_body is sphere
+    # number of forcing grid points is dynamic so cant test here
+    assert sphere_forcing_grid.position_field.shape[0] == grid_dim
+    assert sphere_forcing_grid.velocity_field.shape[0] == grid_dim
+    polar_angle_grid = np.linspace(0, np.pi, num_forcing_points_along_equator // 2)
+    num_forcing_points_along_latitudes = (
+        np.rint(num_forcing_points_along_equator * np.sin(polar_angle_grid)).astype(int)
+        + 1
+    )
+    assert sphere_forcing_grid.num_lag_nodes == sum(num_forcing_points_along_latitudes)
+
+    # check if grid position consistent
+    sphere_com = sphere.position_collection
+    moment_arm = sphere_forcing_grid.position_field - sphere_com
+    grid_distance_from_center = np.linalg.norm(moment_arm, axis=0)
+    # check if all points are at distance = radius from center
+    np.testing.assert_allclose(grid_distance_from_center, sphere.radius)
+    grid_centroid = np.mean(sphere_forcing_grid.position_field, axis=1)
+    np.testing.assert_allclose(grid_centroid, sphere_com[..., 0])
+
+    # check if angular locations are correct
+    x_axis = 0
+    y_axis = 1
+    z_axis = 2
+    num_lag_nodes_idx = 0
+    test_tol = get_test_tol(precision="double")
+    for num_forcing_points_along_latitude, polar_angle in zip(
+        num_forcing_points_along_latitudes, polar_angle_grid
+    ):
+        azimuthal_angle_grid = np.linspace(
+            0.0, 2 * np.pi, num_forcing_points_along_latitude, endpoint=False
+        )
+        np.testing.assert_allclose(
+            moment_arm[
+                x_axis,
+                num_lag_nodes_idx : num_lag_nodes_idx
+                + num_forcing_points_along_latitude,
+            ],
+            sphere.radius * np.sin(polar_angle) * np.cos(azimuthal_angle_grid),
+            atol=test_tol,
+        )
+        np.testing.assert_allclose(
+            moment_arm[
+                y_axis,
+                num_lag_nodes_idx : num_lag_nodes_idx
+                + num_forcing_points_along_latitude,
+            ],
+            sphere.radius * np.sin(polar_angle) * np.sin(azimuthal_angle_grid),
+            atol=test_tol,
+        )
+        np.testing.assert_allclose(
+            moment_arm[
+                z_axis,
+                num_lag_nodes_idx : num_lag_nodes_idx
+                + num_forcing_points_along_latitude,
+            ],
+            sphere.radius * np.cos(polar_angle),
+            atol=test_tol,
+        )
+        num_lag_nodes_idx += num_forcing_points_along_latitude
+
+        # check if velocities are correct
+        correct_velocity_field = np.zeros_like(sphere_forcing_grid.velocity_field)
+        sphere_com_velocity = sphere.velocity_collection[..., 0]
+        for axis in range(grid_dim):
+            # vel = v_com + omega cross r
+            omega_cross_r = (
+                sphere.omega_collection[(axis + 1) % grid_dim]
+                * moment_arm[(axis + 2) % grid_dim]
+                - sphere.omega_collection[(axis + 2) % grid_dim]
+                * moment_arm[(axis + 1) % grid_dim]
+            )
+            correct_velocity_field[axis] = sphere_com_velocity[x_axis] + omega_cross_r
+        np.testing.assert_allclose(
+            correct_velocity_field, sphere_forcing_grid.velocity_field
+        )
+
+
+@pytest.mark.parametrize("num_forcing_points_along_equator", [8, 16])
+def test_sphere_grid_force_transfer(num_forcing_points_along_equator):
+    sphere = mock_3d_sphere()
+    grid_dim = 3
+    sphere_forcing_grid = sps.SphereForcingGrid(
+        grid_dim=grid_dim,
+        rigid_body=sphere,
+        num_forcing_points_along_equator=num_forcing_points_along_equator,
+    )
+    body_flow_forces = np.zeros((grid_dim, 1))
+    body_flow_torques = np.zeros_like(body_flow_forces)
+    lag_grid_forcing_field = np.zeros((grid_dim, sphere_forcing_grid.num_lag_nodes))
+    uniform_forcing = np.random.rand(grid_dim, 1)
+    lag_grid_forcing_field[...] = uniform_forcing
+    sphere_forcing_grid.transfer_forcing_from_grid_to_body(
+        body_flow_forces=body_flow_forces,
+        body_flow_torques=body_flow_torques,
+        lag_grid_forcing_field=lag_grid_forcing_field,
+    )
+    correct_body_flow_forces = np.zeros_like(body_flow_forces)
+    # negative sum
+    correct_body_flow_forces[...] = -uniform_forcing * sphere_forcing_grid.num_lag_nodes
+    np.testing.assert_allclose(body_flow_forces, correct_body_flow_forces)
+
+    sphere_com = sphere.position_collection
+    moment_arm = sphere_forcing_grid.position_field - sphere_com
+    correct_body_flow_torques = np.zeros_like(correct_body_flow_forces)
+    for axis in range(grid_dim):
+        correct_body_flow_torques[axis] = -np.sum(
+            moment_arm[(axis + 1) % grid_dim] * uniform_forcing[(axis + 2) % grid_dim]
+            - moment_arm[(axis + 2) % grid_dim] * uniform_forcing[(axis + 1) % grid_dim]
+        )
+    np.testing.assert_allclose(
+        body_flow_torques,
+        correct_body_flow_torques,
+        atol=get_test_tol(precision="double"),
+    )
+
+
+@pytest.mark.parametrize("num_forcing_points_along_equator", [8, 16])
+def test_sphere_grid_spacing(num_forcing_points_along_equator):
+    sphere = mock_3d_sphere()
+    grid_dim = 3
+    sphere_forcing_grid = sps.SphereForcingGrid(
+        grid_dim=grid_dim,
+        rigid_body=sphere,
+        num_forcing_points_along_equator=num_forcing_points_along_equator,
+    )
+    max_grid_spacing = sphere_forcing_grid.get_maximum_lagrangian_grid_spacing()
+    sphere_equator_circumference = 2 * np.pi * sphere.radius
+    correct_max_grid_spacing = (
+        sphere_equator_circumference / num_forcing_points_along_equator
+    )
+    assert correct_max_grid_spacing == max_grid_spacing


### PR DESCRIPTION
Fixes #154 , merge after #162 

Please find qualitative and quantitative comparisons between `sopht-mpi` and `sopht-examples` below for `grid_size = (64, 64, 128)`. Renderings are done for the same isosurface value of vorticity magnitude as a qualitative check and comparison.

## sopht-mpi
-------------------------------------
https://user-images.githubusercontent.com/12764958/210294364-18e4f78e-8d95-4bf3-9c89-7258c23cb1a6.mp4

## sopht-examples
-------------------------------------
https://user-images.githubusercontent.com/12764958/210294381-7b9ff95a-ebe8-4adc-9745-95a2decbd9c1.mp4

## Drag coefficient comparison
-------------------------------------
<img width="737" alt="image" src="https://user-images.githubusercontent.com/12764958/210294420-1a69eff7-0a09-4f2d-a7ce-64913927939c.png">


