### PR TITLE
Flow past rod

### DIFF
--- a/examples/3d_examples/FlowPastRodCase/flow_past_rod_case.py
+++ b/examples/3d_examples/FlowPastRodCase/flow_past_rod_case.py
@@ -1,0 +1,391 @@
+import click
+import elastica as ea
+import numpy as np
+import sopht_mpi.simulator as sps
+import sopht.utils as spu
+from sopht_mpi.utils import logger
+from sopht_mpi.utils.mpi_io import MPIIO, CosseratRodMPIIO
+from mpi4py import MPI
+from typing import Optional
+
+
+def flow_past_rod_case(
+    non_dim_final_time: float,
+    n_elem: int,
+    grid_size: tuple[int, int, int],
+    surface_grid_density_for_largest_element: int,
+    cauchy_number: float,
+    mass_ratio: float,
+    froude_number: float,
+    stretch_bending_ratio: float,
+    poisson_ratio: float = 0.5,
+    reynolds: float = 100.0,
+    coupling_stiffness: float = -2e5,
+    coupling_damping: float = -1e2,
+    rod_start_incline_angle: float = 0.0,
+    rank_distribution: Optional[tuple[int, int, int]] = None,
+    precision: str = "single",
+    save_data: bool = False,
+) -> None:
+    # =================COMMON SIMULATOR STUFF=======================
+    grid_size_z, grid_size_y, grid_size_x = grid_size
+    real_t = spu.get_real_t(precision)
+    x_axis_idx = spu.VectorField.x_axis_idx()
+    y_axis_idx = spu.VectorField.y_axis_idx()
+    z_axis_idx = spu.VectorField.z_axis_idx()
+    rho_f = 1.0
+    U_free_stream = 1.0
+    base_length = 1.0
+    x_range = 1.8 * base_length
+    y_range = grid_size_y / grid_size_x * x_range
+    z_range = grid_size_z / grid_size_x * x_range
+    velocity_free_stream = [U_free_stream, 0.0, 0.0]
+    # =================PYELASTICA STUFF BEGIN=====================
+
+    class FlowPastRodSimulator(
+        ea.BaseSystemCollection, ea.Constraints, ea.Forcing, ea.Damping
+    ):
+        ...
+
+    flow_past_sim = FlowPastRodSimulator()
+    start = np.array([0.2 * x_range, 0.5 * y_range, 0.75 * z_range])
+    direction = np.array(
+        [np.sin(rod_start_incline_angle), 0.0, -np.cos(rod_start_incline_angle)]
+    )
+    normal = np.array([0.0, 1.0, 0.0])
+    base_diameter = y_range / 5.0
+    base_radius = base_diameter / 2.0
+    base_area = np.pi * base_radius**2
+    # mass_ratio = rho_s / rho_f
+    rho_s = mass_ratio * rho_f
+    moment_of_inertia = np.pi / 4 * base_radius**4
+    # Cau = (rho_f U^2 L^3 D) / EI
+    youngs_modulus = (rho_f * U_free_stream**2 * base_length**3 * base_diameter) / (
+        cauchy_number * moment_of_inertia
+    )
+    # Froude = g L / U^2
+    gravitational_acc = froude_number * U_free_stream**2 / base_diameter
+    # Stretch to Bending ratio EAL2 / EI
+    Es_Eb = stretch_bending_ratio * moment_of_inertia / (base_area * base_length**2)
+
+    flow_past_rod = ea.CosseratRod.straight_rod(
+        n_elem,
+        start,
+        direction,
+        normal,
+        base_length,
+        base_radius,
+        rho_s,
+        0.0,  # internal damping constant, deprecated in v0.3.0
+        youngs_modulus,
+        shear_modulus=youngs_modulus / (poisson_ratio + 1.0),
+    )
+    flow_past_rod.shear_matrix[2, 2, :] *= Es_Eb
+    flow_past_sim.append(flow_past_rod)
+    flow_past_sim.constrain(flow_past_rod).using(
+        ea.OneEndFixedBC, constrained_position_idx=(0,), constrained_director_idx=(0,)
+    )
+    # Add gravitational forces
+    flow_past_sim.add_forcing_to(flow_past_rod).using(
+        ea.GravityForces, acc_gravity=np.array([0.0, 0.0, -gravitational_acc])
+    )
+    # add damping
+    dl = base_length / n_elem
+    rod_dt = 0.01 * dl
+    damping_constant = 1e-3
+    flow_past_sim.dampen(flow_past_rod).using(
+        ea.AnalyticalLinearDamper,
+        damping_constant=damping_constant,
+        time_step=rod_dt,
+    )
+    # =================PYELASTICA STUFF END=====================
+
+    # ==================FLOW SETUP START=========================
+    kinematic_viscosity = U_free_stream * base_diameter / reynolds
+    flow_sim = sps.UnboundedFlowSimulator3D(
+        grid_size=grid_size,
+        x_range=x_range,
+        kinematic_viscosity=kinematic_viscosity,
+        flow_type="navier_stokes_with_forcing",
+        with_free_stream_flow=True,
+        real_t=real_t,
+        rank_distribution=rank_distribution,
+        filter_vorticity=True,
+        filter_setting_dict={"order": 1, "type": "multiplicative"},
+    )
+    # ==================FLOW SETUP END=========================
+
+    # ==================FLOW-ROD COMMUNICATOR SETUP START======
+    master_rank = 0
+    cosserat_rod_flow_interactor = sps.CosseratRodFlowInteraction(
+        mpi_construct=flow_sim.mpi_construct,
+        mpi_ghost_exchange_communicator=flow_sim.mpi_ghost_exchange_communicator,
+        cosserat_rod=flow_past_rod,
+        eul_grid_forcing_field=flow_sim.eul_grid_forcing_field,
+        eul_grid_velocity_field=flow_sim.velocity_field,
+        virtual_boundary_stiffness_coeff=coupling_stiffness,
+        virtual_boundary_damping_coeff=coupling_damping,
+        dx=flow_sim.dx,
+        grid_dim=flow_sim.grid_dim,
+        real_t=real_t,
+        forcing_grid_cls=sps.CosseratRodSurfaceForcingGrid,
+        surface_grid_density_for_largest_element=surface_grid_density_for_largest_element,
+        master_rank=master_rank,
+    )
+    flow_past_sim.add_forcing_to(flow_past_rod).using(
+        sps.FlowForces,
+        cosserat_rod_flow_interactor,
+    )
+    # ==================FLOW-ROD COMMUNICATOR SETUP END======
+    # =================TIMESTEPPING====================
+    flow_past_sim.finalize()
+    timestepper = ea.PositionVerlet()
+    do_step, stages_and_updates = ea.extend_stepper_interface(
+        timestepper, flow_past_sim
+    )
+
+    if save_data:
+        # setup IO
+        # TODO: internalise this into flow simulator in a cleaner way
+        origin_x = flow_sim.mpi_construct.grid.allreduce(
+            flow_sim.position_field[
+                x_axis_idx,
+                flow_sim.ghost_size : -flow_sim.ghost_size,
+                flow_sim.ghost_size : -flow_sim.ghost_size,
+            ].min(),
+            op=MPI.MIN,
+        )
+        origin_y = flow_sim.mpi_construct.grid.allreduce(
+            flow_sim.position_field[
+                y_axis_idx,
+                flow_sim.ghost_size : -flow_sim.ghost_size,
+                flow_sim.ghost_size : -flow_sim.ghost_size,
+            ].min(),
+            op=MPI.MIN,
+        )
+        origin_z = flow_sim.mpi_construct.grid.allreduce(
+            flow_sim.position_field[
+                z_axis_idx,
+                flow_sim.ghost_size : -flow_sim.ghost_size,
+                flow_sim.ghost_size : -flow_sim.ghost_size,
+                flow_sim.ghost_size : -flow_sim.ghost_size,
+            ].min(),
+            op=MPI.MIN,
+        )
+        io_origin = np.array([origin_z, origin_y, origin_x])
+        io_dx = flow_sim.dx * np.ones(flow_sim.grid_dim)
+        io_grid_size = np.array(grid_size)
+        io = MPIIO(mpi_construct=flow_sim.mpi_construct, real_dtype=real_t)
+        io.define_eulerian_grid(
+            origin=io_origin,
+            dx=io_dx,
+            grid_size=io_grid_size,
+            ghost_size=flow_sim.ghost_size,
+        )
+        io.add_as_eulerian_fields_for_io(
+            vorticity=flow_sim.vorticity_field, velocity=flow_sim.velocity_field
+        )
+        # Initialize rod IO
+        rod_io = CosseratRodMPIIO(
+            mpi_construct=flow_sim.mpi_construct,
+            cosserat_rod=flow_past_rod,
+            real_dtype=real_t,
+            master_rank=cosserat_rod_flow_interactor.master_rank,
+        )
+
+    foto_timer = 0.0
+    timescale = base_length / U_free_stream
+    final_time = non_dim_final_time * timescale
+    foto_timer_limit = 1 / 30
+    time_history = []
+    rod_angle = []
+    force_history = []
+
+    def rod_incline_angle_with_horizon(rod: ea.CosseratRod):
+        return np.rad2deg(
+            np.fabs(
+                np.arctan(
+                    (
+                        rod.position_collection[z_axis_idx, -1]
+                        - rod.position_collection[z_axis_idx, 0]
+                    )
+                    / (
+                        rod.position_collection[x_axis_idx, -1]
+                        - rod.position_collection[x_axis_idx, 0]
+                    )
+                )
+            )
+        )
+
+    # iterate
+    while flow_sim.time < final_time:
+        # Save data
+        if foto_timer > foto_timer_limit or foto_timer == 0:
+            foto_timer = 0.0
+            if save_data:
+                io.save(
+                    h5_file_name="sopht_"
+                    + str("%0.4d" % (flow_sim.time * 100))
+                    + ".h5",
+                    time=flow_sim.time,
+                )
+                rod_io.save(
+                    h5_file_name="rod_" + str("%0.4d" % (flow_sim.time * 100)) + ".h5",
+                    time=flow_sim.time,
+                )
+
+            forces = 0.0
+            if flow_sim.mpi_construct.rank == cosserat_rod_flow_interactor.master_rank:
+                time_history.append(flow_sim.time)
+                rod_angle.append(rod_incline_angle_with_horizon(flow_past_rod))
+                forces = np.sum(
+                    cosserat_rod_flow_interactor.global_lag_grid_forcing_field, axis=1
+                )
+                force_history.append(forces.copy())
+
+            # Log some diagnostics
+            logger.info(
+                f"time: {flow_sim.time:.2f} ({(flow_sim.time/final_time*100):2.1f}%), "
+                f"max_vort: {flow_sim.get_max_vorticity():.4f}, "
+                f"rod angle: {rod_incline_angle_with_horizon(flow_past_rod):2.2f}, "
+                f"vort divg. L2 norm: {flow_sim.get_vorticity_divergence_l2_norm():.4f},"
+                " grid deviation L2 error: "
+                f"{cosserat_rod_flow_interactor.get_grid_deviation_error_l2_norm():.6f},"
+                f" total force: {forces},"
+                f" force norm: {np.linalg.norm(forces)}"
+            )
+
+        # compute timestep
+        flow_dt = flow_sim.compute_stable_timestep(dt_prefac=0.5)
+
+        # timestep the rod, through the flow timestep
+        rod_time_steps = int(flow_dt / min(flow_dt, rod_dt))
+        local_rod_dt = flow_dt / rod_time_steps
+        rod_time = flow_sim.time
+        for i in range(rod_time_steps):
+            rod_time = do_step(
+                timestepper, stages_and_updates, flow_past_sim, rod_time, local_rod_dt
+            )
+            # timestep the cosserat_rod_flow_interactor
+            cosserat_rod_flow_interactor.time_step(dt=local_rod_dt)
+        # evaluate feedback/interaction between flow and rod
+        cosserat_rod_flow_interactor()
+
+        flow_sim.time_step(
+            dt=flow_dt,
+            free_stream_velocity=velocity_free_stream,
+        )
+
+        # update timer
+        foto_timer += flow_dt
+
+    # Save data
+    if flow_sim.mpi_construct.rank == master_rank:
+        np.savetxt(
+            "rod_angle_vs_time.csv",
+            np.c_[np.array(time_history), np.array(rod_angle)],
+            delimiter=",",
+            header="time, rod_angle",
+        )
+
+        np.savetxt(
+            "rod_forces_vs_time.csv",
+            np.c_[
+                np.array(time_history),
+                np.array(force_history),
+                np.linalg.norm(np.array(force_history), axis=1),
+            ],
+            delimiter=",",
+            header="time, force x, force y, force z, force norm",
+        )
+
+        if save_data:
+            spu.make_dir_and_transfer_h5_data(dir_name="flow_data_h5")
+
+
+if __name__ == "__main__":
+
+    @click.command()
+    @click.option("--nx", default=128, help="Number of grid points in x direction.")
+    @click.option("--u_free_stream", default=1.1, help="Free stream flow velocity.")
+    def simulate_flow_past_rod(nx: int, u_free_stream: float) -> None:
+        ny = nx // 4
+        nz = nx
+        # in order Z, Y, X
+        grid_size = (nz, ny, nx)
+        surface_grid_density_for_largest_element = nx // 8
+        n_elem = 5 * nx // 16
+
+        logger.info(f"Grid size:  {nz, ny, nx ,} ")
+        logger.info(
+            f"num forcing points around the surface:  {surface_grid_density_for_largest_element}"
+        )
+        logger.info(f"num rod elements: {n_elem}")
+        logger.info(f"Free stream flow velocity: {u_free_stream}")
+
+        final_time = 3.5
+
+        exp_rho_s = 1e3  # kg/m3
+        exp_rho_f = 1.21  # kg/m3
+        exp_youngs_modulus = 2.25e5  # Pa
+        exp_poisson_ratio = 0.01
+        exp_base_length = 25e-3  # m
+        exp_base_diameter = 0.4e-3  # m
+        exp_kinematic_viscosity = 1.51e-5  # m2/s
+        exp_U_free_stream = u_free_stream  # m/s
+        exp_gravitational_acc = 9.80665  # m/s2
+
+        exp_mass_ratio = exp_rho_s / exp_rho_f
+        exp_base_radius = exp_base_diameter / 2
+        exp_base_area = np.pi * exp_base_radius**2
+        exp_moment_of_inertia = np.pi / 4 * exp_base_radius**4
+        exp_bending_rigidity = exp_youngs_modulus * exp_moment_of_inertia
+        exp_cauchy_number = (
+            exp_rho_f
+            * exp_U_free_stream**2
+            * exp_base_length**3
+            * exp_base_diameter
+            / exp_bending_rigidity
+        )
+        # Froude = g D / U^2
+        exp_froude_number = (
+            exp_gravitational_acc * exp_base_diameter / exp_U_free_stream**2
+        )
+        exp_Re = exp_U_free_stream * exp_base_diameter / exp_kinematic_viscosity
+
+        # stretch to bending ratio EAL2 / EI
+        exp_Ks_Kb = (exp_youngs_modulus * exp_base_area * exp_base_length**2) / (
+            exp_youngs_modulus * exp_moment_of_inertia
+        )
+
+        # Drag coefficient from Silvaleon 2018 Eq 10
+        Cd = (1.13 + 11.4 / exp_Re**0.808) ** 0.952
+        # Silvaleon 2018
+        Ca_B = (
+            (2 / np.pi) * Cd * (exp_rho_f / (exp_rho_s - exp_rho_f)) / exp_froude_number
+        )
+        # Final deflection angle Silvaleon 2018 Eq 15
+        rod_start_incline_angle = np.deg2rad(
+            90 - 90 / (1 + 3.32 * Ca_B**1.33) ** 0.407 + 0.5
+        )
+
+        logger.info(
+            f"Re: {exp_Re}, Ca: {exp_cauchy_number}, Fr: {exp_froude_number}, Angle: {rod_start_incline_angle}"
+        )
+
+        flow_past_rod_case(
+            non_dim_final_time=final_time,
+            cauchy_number=exp_cauchy_number,
+            mass_ratio=exp_mass_ratio,
+            froude_number=exp_froude_number,
+            poisson_ratio=exp_poisson_ratio,
+            reynolds=exp_Re,
+            stretch_bending_ratio=exp_Ks_Kb,
+            grid_size=grid_size,
+            surface_grid_density_for_largest_element=surface_grid_density_for_largest_element,
+            n_elem=n_elem,
+            rod_start_incline_angle=rod_start_incline_angle,
+            save_data=True,
+        )
+
+    simulate_flow_past_rod()

--- a/sopht_mpi/simulator/immersed_body/cosserat_rod/__init__.py
+++ b/sopht_mpi/simulator/immersed_body/cosserat_rod/__init__.py
@@ -1,2 +1,7 @@
-from sopht_mpi.simulator.immersed_body.cosserat_rod.cosserat_rod_forcing_grids import *
-from sopht_mpi.simulator.immersed_body.cosserat_rod.cosserat_rod_flow_interaction_mpi import *
+from sopht_mpi.simulator.immersed_body.cosserat_rod.cosserat_rod_forcing_grids import (
+    CosseratRodElementCentricForcingGrid,
+    CosseratRodSurfaceForcingGrid,
+)
+from sopht_mpi.simulator.immersed_body.cosserat_rod.cosserat_rod_flow_interaction_mpi import (
+    CosseratRodFlowInteraction,
+)

--- a/sopht_mpi/simulator/immersed_body/cosserat_rod/cosserat_rod_flow_interaction_mpi.py
+++ b/sopht_mpi/simulator/immersed_body/cosserat_rod/cosserat_rod_flow_interaction_mpi.py
@@ -1,4 +1,3 @@
-__all__ = ["CosseratRodFlowInteraction"]
 from elastica.rod.cosserat_rod import CosseratRod
 import numpy as np
 from sopht_mpi.simulator.immersed_body import (

--- a/sopht_mpi/simulator/immersed_body/cosserat_rod/cosserat_rod_forcing_grids.py
+++ b/sopht_mpi/simulator/immersed_body/cosserat_rod/cosserat_rod_forcing_grids.py
@@ -1,5 +1,5 @@
-__all__ = ["CosseratRodElementCentricForcingGrid"]
-from elastica.rod.cosserat_rod import CosseratRod
+import elastica as ea
+from elastica._linalg import _batch_cross, _batch_matvec, _batch_matrix_transpose
 import numpy as np
 from sopht_mpi.simulator.immersed_body import ImmersedBodyForcingGrid
 from elastica.interaction import node_to_element_velocity
@@ -11,7 +11,7 @@ class CosseratRodElementCentricForcingGrid(ImmersedBodyForcingGrid):
     def __init__(
         self,
         grid_dim,
-        cosserat_rod: type(CosseratRod),
+        cosserat_rod: ea.CosseratRod,
         real_t=np.float64,
     ):
         self.num_lag_nodes = cosserat_rod.n_elems
@@ -55,3 +55,212 @@ class CosseratRodElementCentricForcingGrid(ImmersedBodyForcingGrid):
         """Get the maximum Lagrangian grid spacing"""
         # estimated distance between consecutive elements
         return np.amax(self.cosserat_rod.lengths)
+
+
+# Forcing grid implementation for tapered rod
+class CosseratRodSurfaceForcingGrid(ImmersedBodyForcingGrid):
+    """
+        Class for forcing grid at Cosserat rod element surface points.
+    Notes
+    -----
+        For the 3D simulations of Cosserat rods this grid can be used.
+        Depending on the maximum radius, grid points between different element can vary.
+    """
+
+    def __init__(
+        self,
+        grid_dim: int,
+        cosserat_rod: ea.CosseratRod,
+        surface_grid_density_for_largest_element: int,
+        real_t: type = np.float64,
+    ) -> None:
+        if grid_dim != 3:
+            raise ValueError(
+                "Invalid grid dimensions. Cosserat rod surface forcing grid is only "
+                "defined for grid_dim=3"
+            )
+        self.real_t = real_t
+        self.cosserat_rod = cosserat_rod
+
+        # Surface grid density at the arm maximum radius
+        self.surface_grid_density_for_largest_element = (
+            surface_grid_density_for_largest_element
+        )
+
+        # Surface grid points scaled between different element based on the largest radius.
+        self.surface_grid_points = np.rint(
+            self.cosserat_rod.radius[:]
+            / np.max(self.cosserat_rod.radius[:])
+            * self.surface_grid_density_for_largest_element
+        ).astype(int)
+        # If there are less than 1 point then set it equal to 1 since we will place it on the element center.
+        self.surface_grid_points[np.where(self.surface_grid_points < 3)[0]] = 1
+        self.num_lag_nodes = self.surface_grid_points.sum()
+        super().__init__(grid_dim=grid_dim)
+        self.n_elems = cosserat_rod.n_elems
+
+        self.surface_point_rotation_angle_list = []
+        for i in range(self.n_elems):
+            if self.surface_grid_points[i] > 1:
+                # If there are more than one point on the surface then compute the angle of these points.
+                # Surface points are on the local frame
+                self.surface_point_rotation_angle_list.append(
+                    np.linspace(
+                        0, 2 * np.pi, self.surface_grid_points[i], endpoint=False
+                    )
+                )
+            else:
+                # If there is only one point, then that point is on the element center so pass empty array.
+                self.surface_point_rotation_angle_list.append(np.array([]))
+
+        # Since lag grid points are on the surface, for each node we need to compute moment arm.
+        self.moment_arm = np.zeros_like(self.position_field)
+
+        # Depending on the rod taper number of surface points can vary between elements, so we need start_idx and
+        # end_idx to slice grid points according to element they belong.
+        self.start_idx = np.zeros((self.n_elems), dtype=int)
+        self.end_idx = np.zeros((self.n_elems), dtype=int)
+
+        start_idx_temp = 0
+        end_idx_temp = 0
+        for i in range(self.n_elems):
+            self.start_idx[i] = start_idx_temp
+            start_idx_temp += self.surface_grid_points[i]
+            end_idx_temp += self.surface_grid_points[i]
+            self.end_idx[i] = end_idx_temp
+
+        self.local_frame_surface_points = np.zeros_like(self.position_field)
+
+        # Compute surface(grid) point positions on local frame for each element. If there is one grid point then
+        # that point is on the element center so just pass 0.0
+        for i, surface_point_rotation_angle in enumerate(
+            self.surface_point_rotation_angle_list
+        ):
+            if surface_point_rotation_angle.size == 0:
+                # This is true if there is only one point for element, and it is on element center.
+                self.local_frame_surface_points[
+                    :, self.start_idx[i] : self.end_idx[i]
+                ] = 0.0
+            else:
+                self.local_frame_surface_points[
+                    0, self.start_idx[i] : self.end_idx[i]
+                ] = np.cos(surface_point_rotation_angle)
+                self.local_frame_surface_points[
+                    1, self.start_idx[i] : self.end_idx[i]
+                ] = np.sin(surface_point_rotation_angle)
+
+        # some caching stuff
+        self.rod_director_collection_transpose = np.zeros_like(
+            self.cosserat_rod.director_collection
+        )
+        self.rod_element_position = np.zeros((self.grid_dim, self.n_elems))
+        self.rod_element_velocity = np.zeros_like(self.rod_element_position)
+        self.rod_element_global_frame_omega = np.zeros_like(self.rod_element_position)
+
+        self.grid_point_director_transpose = np.zeros((3, 3, self.num_lag_nodes))
+        self.grid_point_radius = np.zeros((self.num_lag_nodes))
+        self.grid_point_omega = np.zeros_like(self.position_field)
+        self.lag_grid_torque_field = np.zeros_like(self.position_field)
+
+        # to ensure position/velocity are consistent during initialisation
+        self.compute_lag_grid_position_field()
+        self.compute_lag_grid_velocity_field()
+
+    def compute_lag_grid_position_field(self) -> None:
+        """Computes location of forcing grid for the Cosserat rod"""
+
+        self.rod_element_position[...] = 0.5 * (
+            self.cosserat_rod.position_collection[..., 1:]
+            + self.cosserat_rod.position_collection[..., :-1]
+        )
+
+        # Cache rod director collection transpose since it will be used to compute velocity field.
+        self.rod_director_collection_transpose[...] = _batch_matrix_transpose(
+            self.cosserat_rod.director_collection
+        )
+
+        # Broadcast rod properties to the grid points.
+        for i in range(self.n_elems):
+            self.grid_point_director_transpose[
+                :, :, self.start_idx[i] : self.end_idx[i]
+            ] = self.rod_director_collection_transpose[:, :, i : i + 1]
+            self.grid_point_radius[
+                self.start_idx[i] : self.end_idx[i]
+            ] = self.cosserat_rod.radius[i]
+            self.position_field[
+                :, self.start_idx[i] : self.end_idx[i]
+            ] = self.rod_element_position[:, i : i + 1]
+
+        # Compute the moment arm or distance from the element center for each grid point.
+        self.moment_arm[:] = self.grid_point_radius * _batch_matvec(
+            self.grid_point_director_transpose, self.local_frame_surface_points
+        )
+
+        # Surface positions are moment_arm + element center position
+        self.position_field += self.moment_arm
+
+    def compute_lag_grid_velocity_field(self) -> None:
+        """Computes velocity of forcing grid points for the Cosserat rod"""
+
+        # Element velocity
+        self.rod_element_velocity[...] = node_to_element_velocity(
+            self.cosserat_rod.mass, self.cosserat_rod.velocity_collection
+        )
+        # Element angular velocity
+        self.rod_element_global_frame_omega[...] = _batch_matvec(
+            self.rod_director_collection_transpose,
+            self.cosserat_rod.omega_collection,
+        )
+
+        # Broadcast rod properties to the grid points.
+        for i in range(self.n_elems):
+            self.grid_point_omega[
+                :, self.start_idx[i] : self.end_idx[i]
+            ] = self.rod_element_global_frame_omega[:, i : i + 1]
+            self.velocity_field[
+                :, self.start_idx[i] : self.end_idx[i]
+            ] = self.rod_element_velocity[:, i : i + 1]
+
+        # v_elem + omega X moment_arm
+        self.velocity_field += _batch_cross(self.grid_point_omega, self.moment_arm)
+
+    def transfer_forcing_from_grid_to_body(
+        self,
+        body_flow_forces: np.ndarray,
+        body_flow_torques: np.ndarray,
+        lag_grid_forcing_field: np.ndarray,
+    ) -> None:
+        """Transfer forcing from lagrangian forcing grid to the cosserat rod"""
+        body_flow_forces[...] = 0.0
+        body_flow_torques[...] = 0.0
+
+        # negative sign due to Newtons third law
+        for i in range(self.n_elems):
+            body_forces_on_elems = np.sum(
+                lag_grid_forcing_field[:, self.start_idx[i] : self.end_idx[i]], axis=1
+            )
+            body_flow_forces[:, i] -= 0.5 * body_forces_on_elems
+            body_flow_forces[:, i + 1] -= 0.5 * body_forces_on_elems
+
+        # negative sign due to Newtons third law
+        # torque generated by all lagrangian points are
+        self.lag_grid_torque_field[...] = _batch_cross(
+            self.moment_arm, -lag_grid_forcing_field
+        )
+
+        # Update body torques
+        # convert global to local frame
+        for i in range(self.n_elems):
+            body_flow_torques[:, i] = self.cosserat_rod.director_collection[
+                :, :, i
+            ] @ np.sum(
+                self.lag_grid_torque_field[:, self.start_idx[i] : self.end_idx[i]],
+                axis=1,
+            )
+
+    def get_maximum_lagrangian_grid_spacing(self) -> float:
+        """Get the maximum Lagrangian grid spacing"""
+        grid_angular_spacing = 2 * np.pi / self.surface_grid_density_for_largest_element
+        return np.amax(
+            [self.cosserat_rod.lengths, self.cosserat_rod.radius * grid_angular_spacing]
+        )


### PR DESCRIPTION
Fixes #164 , merge after #163 since I created this branch from that.

Please find qualitative and quantitative comparisons between `sopht-mpi` and `sopht-examples` below, both simulated using [default settings](https://github.com/SophT-Team/SophT-Simulator/blob/main/examples/3d_examples/FlowPastRodCase/flow_past_rod_case.py) in `sopht-simulator`. Renderings are done for the same isosurface value of vorticity magnitude as a qualitative check and comparison.

## sopht-mpi
-------------------------------------
https://user-images.githubusercontent.com/12764958/210315442-5a36eb3c-e65c-4db5-9f71-275a75ce500e.mp4

## sopht-examples
-------------------------------------
https://user-images.githubusercontent.com/12764958/210315471-f96d9a81-8c11-414b-9f9f-ecb1cf3c9fce.mp4

## Rod forces and angle comparison
-------------------------------------
<img width="737" alt="image" src="https://user-images.githubusercontent.com/12764958/210315598-608660fa-eb57-4dc4-b211-1853eee34dec.png">
<img width="739" alt="image" src="https://user-images.githubusercontent.com/12764958/210315619-2e1b14dd-f372-4b5c-8381-ccd9ece2845d.png">

