### PR TITLE
Cluster setup for expanse and stampede2

### DIFF
--- a/doc/clusters/README.md
+++ b/doc/clusters/README.md
@@ -1,0 +1,20 @@
+# Installation on supercomputing clusters
+Installation on supercomputing clusters are mostly similar to how installation is done
+your local machine, with a few pre-installation steps involving loading readily
+available modules and setting relevant environment variables.
+Once you have completed the pre-installation steps according to the cluster of your
+choice, you should be ready to proceed with the installation steps as detailed in the
+[main repository](https://github.com/fankiat/sopht-mpi).
+
+## Expanse
+1. Load the relevant modules and set environment variables as below.
+```bash
+module load gcc openmpi anaconda3 hdf5
+export HDF5_DIR=$HDF5HOME
+```
+2. Proceed with usual installation steps as detailed in the [main repository](https://github.com/fankiat/sopht-mpi).
+
+
+# Submitting jobs on cluster
+Once you have setup the solver on your desired cluster, you can submit jobs using the
+batch submission scripts provided here as reference.

--- a/doc/clusters/README.md
+++ b/doc/clusters/README.md
@@ -5,16 +5,44 @@ available modules and setting relevant environment variables.
 Once you have completed the pre-installation steps according to the cluster of your
 choice, you should be ready to proceed with the installation steps as detailed in the
 [main repository](https://github.com/fankiat/sopht-mpi).
+*Please note that you should skip **step 3** of the installation process detailed there
+since the non-python modules are loaded on the cluster environment after taking the
+pre-installation steps below*
 
 ## Expanse
 1. Load the relevant modules and set environment variables as below.
 ```bash
+module reset
 module load gcc openmpi anaconda3 hdf5
 export HDF5_DIR=$HDF5HOME
 ```
-2. Proceed with usual installation steps as detailed in the [main repository](https://github.com/fankiat/sopht-mpi).
+2. Create python virtual environment and proceed with usual installation steps as
+detailed in the [main repository](https://github.com/fankiat/sopht-mpi) (skipping step
+3).
+
+
+## Stampede2
+1. Load the relevant modules and set environment variables as below. Here we unload the
+old Python 2.7 version to remove older, unnecessary reference of `PYTHONPATH` to ensure
+smooth installation of `sopht-mpi`. We also use the default modules on `Stampede2`,
+which includes `Intel-MPI`.
+```bash
+module reset
+module unload python2 # remove unnecessary python2
+module load phdf5
+export HDF5_DIR=$TACC_HDF5_DIR
+```
+
+2. Since `anaconda` is not an available module on `Stampede2`, we need to install
+miniconda separately. Detailed steps on installation can be found in
+[TACC wiki](https://wikis.utexas.edu/display/bioiteam/Linux+and+stampede2+Setup+--+GVA2021#Linuxandstampede2SetupGVA2021-MovingbeyondthepreinstalledcommandsonTACC)
+and [Miniconda documentation](https://docs.conda.io/en/latest/miniconda.html) page.
+
+3. Create python virtual environment and proceed with usual installation steps as
+detailed in the [main repository](https://github.com/fankiat/sopht-mpi) (skipping step
+3).
 
 
 # Submitting jobs on cluster
 Once you have setup the solver on your desired cluster, you can submit jobs using the
-batch submission scripts provided here as reference.
+`submit_*.sh` batch submission scripts provided as reference.

--- a/doc/clusters/submit_expanse.sh
+++ b/doc/clusters/submit_expanse.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+#SBATCH -J test_expanse
+#SBATCH -o %x_%j.out                    # Name of stdout output file
+#SBATCH -e %x_%j.err                    # Name of stderr error file
+#SBATCH -p compute                      # Queue (partition) name
+#SBATCH -N 4                            # Number of nodes requested
+#SBATCH --ntasks-per-node=128           # Number of processes/tasks per node
+#SBATCH --mem=249325M                   # Memory per compute node (set to expanse limit)
+#SBATCH --export=ALL                    # Propagate all user's environment variables
+#SBATCH -t 00:10:00                     # Run time (hh:mm:ss)
+#SBATCH --mail-user=email@email.edu     # User to receive email notification
+#SBATCH --mail-type=all                 # Send email at begin, end, or fail of job
+#SBATCH --account=TG-MCB190004          # Account to charge resources used by this job
+
+# Other commands must follow all #SBATCH directives...
+
+# File to be executed
+PROGNAME="flow_past_sphere_case.py"
+
+# Print some details on launched job
+date
+echo Job name: $SLURM_JOB_NAME
+echo Execution dir: $SLURM_SUBMIT_DIR
+echo Number of processes: $SLURM_NTASKS
+
+# Reset and load relevant module on expanse
+module reset
+module load gcc openmpi hdf5 anaconda3
+source activate sopht-mpi
+# Print loaded python (sanity check for correctly loaded environment)
+which python
+
+# Execute the program
+mpiexec -n ${SLURM_NTASKS} python -u ${PROGNAME}

--- a/doc/clusters/submit_stampede2.sh
+++ b/doc/clusters/submit_stampede2.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 
-#SBATCH -J test_expanse
+#SBATCH -J test_stampede
 #SBATCH -o %x_%j.out                    # Name of stdout output file
 #SBATCH -e %x_%j.err                    # Name of stderr error file
 #SBATCH -p compute                      # Queue (partition) name
 #SBATCH -N 4                            # Number of nodes requested
-#SBATCH --ntasks-per-node=128           # Number of processes/tasks per node
-#SBATCH --mem=249325M                   # Memory per compute node (set to expanse limit)
+#SBATCH --ntasks-per-node=64            # Number of processes/tasks per node
 #SBATCH --export=ALL                    # Propagate all user's environment variables
 #SBATCH -t 00:10:00                     # Run time (hh:mm:ss)
 #SBATCH --mail-user=email@email.edu     # User to receive email notification
@@ -24,13 +23,17 @@ echo Job name: $SLURM_JOB_NAME
 echo Execution dir: $SLURM_SUBMIT_DIR
 echo Number of processes: $SLURM_NTASKS
 
-# Setup relevant module on expanse
+# Setup relevant module on stampede2
 module reset
-module load gcc openmpi hdf5 anaconda3
+module unload python2
+# Other mpi libraries are loaded by default (intel mpi)
 source deactivate # deactivate any existing environment
 source activate sopht-mpi-env
 # Print loaded python (sanity check for correctly loaded environment)
 which python
 
 # Execute the program
-mpiexec -n ${SLURM_NTASKS} python -u ${PROGNAME}
+# Use ibrun instead of mpirun or mpiexec
+# The number of processes will spawn automatically according to the resources requested
+# Number of processes = number of nodes * number of tasks/processes per node
+ibrun python -u ${PROGNAME}

--- a/doc/clusters/submit_stampede2.sh
+++ b/doc/clusters/submit_stampede2.sh
@@ -26,6 +26,7 @@ echo Number of processes: $SLURM_NTASKS
 # Setup relevant module on stampede2
 module reset
 module unload python2
+module load phdf5
 # Other mpi libraries are loaded by default (intel mpi)
 source deactivate # deactivate any existing environment
 source activate sopht-mpi-env


### PR DESCRIPTION
Fixes #170 and #171 .

I'm thinking we could perhaps use the `submit.py` available in `sopht` for generating the scripts, but that would need to be amended with `mpiexec` / `ibrun` calls etc. For now, I have pushed template scripts for submission on each cluster as reference, subject to removal in the future, depending on how we decide to proceed.