### PR TITLE
Allow toggling of optional MPI communication

### DIFF
--- a/examples/2d_examples/FlowPastCylinderCase/flow_past_cylinder.py
+++ b/examples/2d_examples/FlowPastCylinderCase/flow_past_cylinder.py
@@ -70,7 +70,6 @@ def flow_past_cylinder_boundary_forcing_case(
         virtual_boundary_damping_coeff=coupling_damping,
         dx=flow_sim.dx,
         grid_dim=flow_sim.grid_dim,
-        moving_body=False,  # initialize as non-moving boundary
         master_rank=master_rank,
         forcing_grid_cls=CircularCylinderForcingGrid,
         num_forcing_points=num_lag_nodes,

--- a/examples/3d_examples/FlowPastSphereCase/flow_past_sphere_case.py
+++ b/examples/3d_examples/FlowPastSphereCase/flow_past_sphere_case.py
@@ -76,7 +76,6 @@ def flow_past_sphere_case(
         virtual_boundary_damping_coeff=coupling_damping,
         dx=flow_sim.dx,
         grid_dim=flow_sim.grid_dim,
-        moving_body=False,  # initialize as non-moving boundary
         master_rank=master_rank,
         forcing_grid_cls=SphereForcingGrid,
         num_forcing_points_along_equator=num_forcing_points_along_equator,

--- a/sopht_mpi/simulator/flow/flow_simulators_mpi_3d.py
+++ b/sopht_mpi/simulator/flow/flow_simulators_mpi_3d.py
@@ -114,8 +114,11 @@ class UnboundedFlowSimulator3D:
             real_t=self.real_t,
             rank_distribution=self.rank_distribution,
         )
+        need_full_exchange = self.flow_type == "navier_stokes_with_forcing"
         self.mpi_ghost_exchange_communicator = MPIGhostCommunicator3D(
-            ghost_size=self.ghost_size, mpi_construct=self.mpi_construct
+            ghost_size=self.ghost_size,
+            mpi_construct=self.mpi_construct,
+            full_exchange=need_full_exchange,
         )
 
     def init_domain(self):

--- a/sopht_mpi/simulator/immersed_body/cosserat_rod/cosserat_rod_flow_interaction_mpi.py
+++ b/sopht_mpi/simulator/immersed_body/cosserat_rod/cosserat_rod_flow_interaction_mpi.py
@@ -27,6 +27,8 @@ class CosseratRodFlowInteraction(ImmersedBodyFlowInteractionMPI):
         enable_eul_grid_forcing_reset=False,
         start_time=0.0,
         master_rank=0,
+        assume_data_locality=False,
+        auto_ghosting=True,
         **forcing_grid_kwargs,
     ):
         """Class initialiser."""
@@ -61,4 +63,6 @@ class CosseratRodFlowInteraction(ImmersedBodyFlowInteractionMPI):
             interp_kernel_width=interp_kernel_width,
             enable_eul_grid_forcing_reset=enable_eul_grid_forcing_reset,
             start_time=start_time,
+            assume_data_locality=assume_data_locality,
+            auto_ghosting=auto_ghosting,
         )

--- a/sopht_mpi/simulator/immersed_body/rigid_body/rigid_body_flow_interaction_mpi.py
+++ b/sopht_mpi/simulator/immersed_body/rigid_body/rigid_body_flow_interaction_mpi.py
@@ -26,8 +26,9 @@ class RigidBodyFlowInteractionMPI(ImmersedBodyFlowInteractionMPI):
         interp_kernel_width=None,
         enable_eul_grid_forcing_reset=False,
         start_time=0.0,
-        moving_body=True,
         master_rank=0,
+        assume_data_locality=False,
+        auto_ghosting=True,
         **forcing_grid_kwargs,
     ):
         """Class initialiser."""
@@ -58,5 +59,6 @@ class RigidBodyFlowInteractionMPI(ImmersedBodyFlowInteractionMPI):
             interp_kernel_width=interp_kernel_width,
             enable_eul_grid_forcing_reset=enable_eul_grid_forcing_reset,
             start_time=start_time,
-            moving_body=moving_body,
+            assume_data_locality=assume_data_locality,
+            auto_ghosting=auto_ghosting,
         )

--- a/tests/test_numeric/test_immersed_boundary_ops/test_virtual_boundary_forcing_mpi_2d.py
+++ b/tests/test_numeric/test_immersed_boundary_ops/test_virtual_boundary_forcing_mpi_2d.py
@@ -169,7 +169,6 @@ def test_mpi_virtual_boundary_forcing_init_2d(
         dx=ref_virtual_boundary_forcing.dx,
         start_time=ref_virtual_boundary_forcing.time,
         global_lag_grid_position_field=global_ref_lag_grid_position_field,
-        moving_boundary=True,
     )
 
     # 3. Test initialized variables and field buffers

--- a/tests/test_numeric/test_immersed_boundary_ops/test_virtual_boundary_forcing_mpi_3d.py
+++ b/tests/test_numeric/test_immersed_boundary_ops/test_virtual_boundary_forcing_mpi_3d.py
@@ -185,7 +185,6 @@ def test_mpi_virtual_boundary_forcing_init_3d(
         dx=ref_virtual_boundary_forcing.dx,
         start_time=ref_virtual_boundary_forcing.time,
         global_lag_grid_position_field=global_ref_lag_grid_position_field,
-        moving_boundary=True,
     )
 
     # 3. Test initialized variables and field buffers


### PR DESCRIPTION
Fixes #177 . This PR serves to provide flexibilty for MPI communication reduction where the user sees fit. I have tested the implementation with the currently available examples and they reproduced the same results as before.

The changes in this PR will facilitate #176 , where the cilia can be organized such that they maintain data locality (i.e. lagrangian grid in a rank stays within the same local rank eulerian grid) throughout the simulation.