### PR TITLE
Fix MPIIO precision inconsistency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ install:
 	# install parallel h5py
 	# HDF5_MPI="ON" CC=mpicc pip install --no-binary=h5py h5py
 	# Temporary parallel h5py workaround until h5py release version >3.8.0
-	pip install wheel cython
+	pip install wheel cython pkgconfig
 	HDF5_MPI="ON" CC=mpicc pip install --no-build-isolation --no-binary=h5py h5py
 	# install mpi4py-fft
 	pip install mpi4py-fft

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,10 @@ install:
 	# uninstall serial h5py coming from sopht-backend
 	pip uninstall -y h5py
 	# install parallel h5py
-	HDF5_MPI="ON" CC=mpicc pip install --no-binary=h5py h5py
+	# HDF5_MPI="ON" CC=mpicc pip install --no-binary=h5py h5py
+	# Temporary parallel h5py workaround until h5py release version >3.8.0
+	pip install wheel cython
+	HDF5_MPI="ON" CC=mpicc pip install --no-build-isolation --no-binary=h5py h5py
 	# install mpi4py-fft
 	pip install mpi4py-fft
 	# sadly pip ffmpeg doesnt work, hence we use conda for ffmpeg

--- a/examples/2d_examples/FlowPastRodCase/flow_past_rod.py
+++ b/examples/2d_examples/FlowPastRodCase/flow_past_rod.py
@@ -177,7 +177,6 @@ def flow_past_rod_case(
         rod_io = CosseratRodMPIIO(
             mpi_construct=flow_sim.mpi_construct,
             cosserat_rod=flow_past_rod,
-            real_dtype=real_t,
             master_rank=master_rank,
         )
 

--- a/examples/3d_examples/FlowPastRodCase/flow_past_rod_case.py
+++ b/examples/3d_examples/FlowPastRodCase/flow_past_rod_case.py
@@ -189,7 +189,6 @@ def flow_past_rod_case(
         rod_io = CosseratRodMPIIO(
             mpi_construct=flow_sim.mpi_construct,
             cosserat_rod=flow_past_rod,
-            real_dtype=real_t,
             master_rank=cosserat_rod_flow_interactor.master_rank,
         )
 

--- a/examples/3d_examples/FlowPastSphereCase/flow_past_sphere_case.py
+++ b/examples/3d_examples/FlowPastSphereCase/flow_past_sphere_case.py
@@ -126,7 +126,10 @@ def flow_past_sphere_case(
             vorticity=flow_sim.vorticity_field, velocity=flow_sim.velocity_field
         )
         # Initialize sphere IO
-        sphere_io = MPIIO(mpi_construct=flow_sim.mpi_construct, real_dtype=real_t)
+        sphere_io = MPIIO(
+            mpi_construct=flow_sim.mpi_construct,
+            real_dtype=sphere.position_collection.dtype,
+        )
         # Add vector field on lagrangian grid
         sphere_io.add_as_lagrangian_fields_for_io(
             lagrangian_grid=sphere_flow_interactor.forcing_grid.position_field,


### PR DESCRIPTION
Fixes #183 

Note: I have also included a temporary fix for #182  in `Makefile` so that CI can install `h5py`. This temporary fix will be removed after `h5py` release the next version.